### PR TITLE
List blogpost based on requester's role and post's status

### DIFF
--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -6,14 +6,32 @@ defmodule Tqm.Blog do
   import Ecto.Query, warn: false
   alias Tqm.Repo
 
-  alias Tqm.Accounts.Person
   alias Tqm.Blog.BlogPost
 
-  #  Returns an unpaginated list of published blog_posts
-  #
-  # A blog post is "published" if its `published_at` value is not `nil`
-  # and is in the past.
-  defp list_published_blog_posts() do
+  @doc """
+  Returns an unpaginated list of blog_posts.
+
+  Optionally an atom: `:published` and `:all`. The default value is
+  `:published`, which will only return blog_posts that have a `published_at`
+  value that is in the past. Passing `:all` will return all blog_posts which
+  includes published blog_posts as well as blog_posts with a `published_at`
+  of `nil` or a future date.
+
+  ## Examples
+
+      iex> list_blog_posts()
+      [%BlogPost{}, ...]
+
+      iex> list_blog_posts(:published)
+      [%BlogPost{}, ...]
+
+      iex> list_blog_posts(:all)
+      [%BlogPost{}, %BlogPost{published_at: nil}, ...]
+
+  """
+  def list_blog_posts(), do: list_blog_posts(:published)
+
+  def list_blog_posts(:published) do
     time_now = NaiveDateTime.utc_now()
 
     Repo.all(
@@ -21,35 +39,7 @@ defmodule Tqm.Blog do
     )
   end
 
-  @doc """
-  Returns an unpaginated list of blog_posts.
-
-  Optionally takes a `%Person{}` as a parameter. If the person is not an
-  owner, only "published" blog posts will be returned. If the person is an
-  owner, all blog posts will be returned.
-
-  ## Examples
-
-      iex> list_blog_posts()
-      [%BlogPost{}, ...]
-
-      iex> list_blog_posts(%Person{role: })
-      [%BlogPost{}, ...]
-
-      iex> list_blog_posts(%Person{role: owner})
-      [%BlogPost{}, ...]
-
-  """
-  def list_blog_posts(), do: list_published_blog_posts()
-  def list_blog_posts(nil), do: list_published_blog_posts()
-
-  def list_blog_posts(%Person{} = person) do
-    if Person.owner?(person) do
-      Repo.all(BlogPost)
-    else
-      list_published_blog_posts()
-    end
-  end
+  def list_blog_posts(:all), do: Repo.all(BlogPost)
 
   @doc """
   Gets a single blog_post.

--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -6,7 +6,37 @@ defmodule Tqm.Blog do
   import Ecto.Query, warn: false
   alias Tqm.Repo
 
+  alias Tqm.Accounts.Person
   alias Tqm.Blog.BlogPost
+
+  @doc """
+  Returns an atom denoting blog_post viewing permissions a person has.
+
+  Possible return values: `:published`, `:all`
+
+  ## Examples
+    iex> viewing_permissions_for_person()
+    :published
+
+    iex> viewing_permissions_for_person(nil)
+    :published
+
+    iex> viewing_permissions_for_person(%Person{role: :stranger})
+    :published
+
+    iex> viewing_permissions_for_person(%Person{role: :owner})
+    :all
+  """
+  def viewing_permissions_for_person(), do: :published
+  def viewing_permissions_for_person(nil), do: :published
+
+  def viewing_permissions_for_person(%Person{} = person) do
+    if Person.owner?(person) do
+      :all
+    else
+      :published
+    end
+  end
 
   @doc """
   Returns an unpaginated list of blog_posts.

--- a/lib/tqm/blog/blog_post.ex
+++ b/lib/tqm/blog/blog_post.ex
@@ -15,6 +15,6 @@ defmodule Tqm.Blog.BlogPost do
   def changeset(blog_post, attrs) do
     blog_post
     |> cast(attrs, [:title, :content, :published_at])
-    |> validate_required([:title, :content, :published_at])
+    |> validate_required([:title, :content])
   end
 end

--- a/lib/tqm_web/controllers/blog_post_controller.ex
+++ b/lib/tqm_web/controllers/blog_post_controller.ex
@@ -1,19 +1,14 @@
 defmodule TqmWeb.BlogPostController do
   use TqmWeb, :controller
 
-  alias Tqm.Accounts.Person
   alias Tqm.Blog
   alias Tqm.Blog.BlogPost
 
   def index(conn, _params) do
-    current_person = conn.assigns[:current_person]
-
     blog_posts =
-      if Person.owner?(current_person) do
-        Blog.list_blog_posts(:all)
-      else
-        Blog.list_blog_posts(:published)
-      end
+      conn.assigns[:current_person]
+      |> Blog.viewing_permissions_for_person()
+      |> Blog.list_blog_posts()
 
     render(conn, :index, tlp: :blog, blog_posts: blog_posts)
   end

--- a/lib/tqm_web/controllers/blog_post_controller.ex
+++ b/lib/tqm_web/controllers/blog_post_controller.ex
@@ -5,7 +5,10 @@ defmodule TqmWeb.BlogPostController do
   alias Tqm.Blog.BlogPost
 
   def index(conn, _params) do
-    blog_posts = Blog.list_blog_posts()
+    blog_posts =
+      conn.assigns[:current_person]
+      |> Blog.list_blog_posts()
+
     render(conn, :index, tlp: :blog, blog_posts: blog_posts)
   end
 

--- a/lib/tqm_web/controllers/blog_post_controller.ex
+++ b/lib/tqm_web/controllers/blog_post_controller.ex
@@ -1,13 +1,19 @@
 defmodule TqmWeb.BlogPostController do
   use TqmWeb, :controller
 
+  alias Tqm.Accounts.Person
   alias Tqm.Blog
   alias Tqm.Blog.BlogPost
 
   def index(conn, _params) do
+    current_person = conn.assigns[:current_person]
+
     blog_posts =
-      conn.assigns[:current_person]
-      |> Blog.list_blog_posts()
+      if Person.owner?(current_person) do
+        Blog.list_blog_posts(:all)
+      else
+        Blog.list_blog_posts(:published)
+      end
 
     render(conn, :index, tlp: :blog, blog_posts: blog_posts)
   end

--- a/test/support/fixtures/blog_fixtures.ex
+++ b/test/support/fixtures/blog_fixtures.ex
@@ -5,7 +5,7 @@ defmodule Tqm.BlogFixtures do
   """
 
   @doc """
-  Generate a blog_post.
+  Generate a published blog_post.
   """
   def blog_post_fixture(attrs \\ %{}) do
     {:ok, blog_post} =
@@ -13,7 +13,39 @@ defmodule Tqm.BlogFixtures do
       |> Enum.into(%{
         content: "some content",
         published_at: ~U[2023-01-28 02:26:00Z],
-        title: "some title"
+        title: "some title 1"
+      })
+      |> Tqm.Blog.create_blog_post()
+
+    blog_post
+  end
+
+  @doc """
+  Generate an unpublished blog_post.
+  """
+  def unpublished_blog_post_fixture(attrs \\ %{}) do
+    {:ok, blog_post} =
+      attrs
+      |> Enum.into(%{
+        content: "some content",
+        published_at: nil,
+        title: "some title 2"
+      })
+      |> Tqm.Blog.create_blog_post()
+
+    blog_post
+  end
+
+  @doc """
+  Generate a future published blog_post.
+  """
+  def future_blog_post_fixture(attrs \\ %{}) do
+    {:ok, blog_post} =
+      attrs
+      |> Enum.into(%{
+        content: "some content",
+        published_at: NaiveDateTime.add(NaiveDateTime.utc_now(), 1, :day),
+        title: "some title 3"
       })
       |> Tqm.Blog.create_blog_post()
 

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -28,19 +28,13 @@ defmodule Tqm.BlogTest do
       assert Blog.list_blog_posts() == [blog_post]
     end
 
-    test "list_blog_posts/1 returns blog posts respective to person role" do
+    test "list_blog_posts/1 returns blog posts dependent on passed atom" do
       blog_post = blog_post_fixture()
       unpublished_blog_post = unpublished_blog_post_fixture()
       future_blog_post = future_blog_post_fixture()
 
-      owner = owner_person_fixture()
-      non_stranger = non_stranger_person_fixture()
-      stranger = stranger_person_fixture()
-
-      assert Blog.list_blog_posts(owner) == [blog_post, unpublished_blog_post, future_blog_post]
-      assert Blog.list_blog_posts(non_stranger) == [blog_post]
-      assert Blog.list_blog_posts(stranger) == [blog_post]
-      assert Blog.list_blog_posts(nil) == [blog_post]
+      assert Blog.list_blog_posts(:all) == [blog_post, unpublished_blog_post, future_blog_post]
+      assert Blog.list_blog_posts(:published) == [blog_post]
     end
 
     test "get_blog_post!/1 returns the blog_post with given id" do

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -21,6 +21,17 @@ defmodule Tqm.BlogTest do
     }
     @invalid_attrs %{content: nil, published_at: nil, title: nil}
 
+    test "viewing_permissions_for_person/0 returns expected value" do
+      assert Blog.viewing_permissions_for_person() == :published
+    end
+
+    test "viewing_permissions_for_person/1 returns expected value" do
+      assert Blog.viewing_permissions_for_person(nil) == :published
+      assert Blog.viewing_permissions_for_person(stranger_person_fixture()) == :published
+      assert Blog.viewing_permissions_for_person(non_stranger_person_fixture()) == :published
+      assert Blog.viewing_permissions_for_person(owner_person_fixture()) == :all
+    end
+
     test "list_blog_posts/0 returns all published blog posts" do
       blog_post = blog_post_fixture()
       unpublished_blog_post_fixture()

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -7,6 +7,7 @@ defmodule Tqm.BlogTest do
     alias Tqm.Blog.BlogPost
 
     import Tqm.BlogFixtures
+    import Tqm.AccountsFixtures
 
     @published_valid_attrs %{
       content: "some content",
@@ -20,9 +21,26 @@ defmodule Tqm.BlogTest do
     }
     @invalid_attrs %{content: nil, published_at: nil, title: nil}
 
-    test "list_blog_posts/0 returns all blog_posts" do
+    test "list_blog_posts/0 returns all published blog posts" do
       blog_post = blog_post_fixture()
+      unpublished_blog_post_fixture()
+      future_blog_post_fixture()
       assert Blog.list_blog_posts() == [blog_post]
+    end
+
+    test "list_blog_posts/1 returns blog posts respective to person role" do
+      blog_post = blog_post_fixture()
+      unpublished_blog_post = unpublished_blog_post_fixture()
+      future_blog_post = future_blog_post_fixture()
+
+      owner = owner_person_fixture()
+      non_stranger = non_stranger_person_fixture()
+      stranger = stranger_person_fixture()
+
+      assert Blog.list_blog_posts(owner) == [blog_post, unpublished_blog_post, future_blog_post]
+      assert Blog.list_blog_posts(non_stranger) == [blog_post]
+      assert Blog.list_blog_posts(stranger) == [blog_post]
+      assert Blog.list_blog_posts(nil) == [blog_post]
     end
 
     test "get_blog_post!/1 returns the blog_post with given id" do

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -8,6 +8,16 @@ defmodule Tqm.BlogTest do
 
     import Tqm.BlogFixtures
 
+    @published_valid_attrs %{
+      content: "some content",
+      published_at: ~U[2023-01-28 02:26:00Z],
+      title: "some title"
+    }
+    @unpublished_valid_attrs %{
+      content: "in progress",
+      published_at: nil,
+      title: "post I want to do"
+    }
     @invalid_attrs %{content: nil, published_at: nil, title: nil}
 
     test "list_blog_posts/0 returns all blog_posts" do
@@ -21,16 +31,15 @@ defmodule Tqm.BlogTest do
     end
 
     test "create_blog_post/1 with valid data creates a blog_post" do
-      valid_attrs = %{
-        content: "some content",
-        published_at: ~U[2023-01-28 02:26:00Z],
-        title: "some title"
-      }
+      assert {:ok, %BlogPost{} = blog_post} = Blog.create_blog_post(@published_valid_attrs)
+      assert blog_post.content == @published_valid_attrs.content
+      assert blog_post.published_at == @published_valid_attrs.published_at
+      assert blog_post.title == @published_valid_attrs.title
 
-      assert {:ok, %BlogPost{} = blog_post} = Blog.create_blog_post(valid_attrs)
-      assert blog_post.content == "some content"
-      assert blog_post.published_at == ~U[2023-01-28 02:26:00Z]
-      assert blog_post.title == "some title"
+      assert {:ok, %BlogPost{} = blog_post} = Blog.create_blog_post(@unpublished_valid_attrs)
+      assert blog_post.content == @unpublished_valid_attrs.content
+      assert blog_post.published_at == @unpublished_valid_attrs.published_at
+      assert blog_post.title == @unpublished_valid_attrs.title
     end
 
     test "create_blog_post/1 with invalid data returns error changeset" do


### PR DESCRIPTION
There will be blogposts which are "unpublished" which means they either have a future set publication date or don't have a publication date set yet. Only the owner should be able to see in the blogpost index (`/blog`) posts which are unpublished.