### PR TITLE
Update Elixir and Erlang in infrastructure

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -40,8 +40,8 @@ jobs:
       # Specify the OTP and Elixir versions to use when building
       # and running the workflow steps.
       matrix:
-        otp: ['25.2']       # Define the OTP version [required]
-        elixir: ['1.14.2']    # Define the elixir version [required]
+        otp: ['26.2.1']       # Define the OTP version [required]
+        elixir: ['1.16.0']    # Define the elixir version [required]
     steps:
     # Step: Setup Elixir + Erlang image as the base.
     - name: Set up Elixir

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,13 +7,13 @@
 # This file is based on these images:
 #
 #   - https://hub.docker.com/r/hexpm/elixir/tags - for the build image
-#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20221004-slim - for the release image
+#   - https://hub.docker.com/_/debian?tab=tags&page=1&name=bullseye-20231009-slim - for the release image
 #   - https://pkgs.org/ - resource for finding needed packages
-#   - Ex: hexpm/elixir:1.14.2-erlang-25.2-debian-bullseye-20221004-slim
+#   - Ex: hexpm/elixir:1.16.0-erlang-26.2.1-debian-bullseye-20231009-slim
 #
-ARG ELIXIR_VERSION=1.14.2
-ARG OTP_VERSION=25.2
-ARG DEBIAN_VERSION=bullseye-20221004-slim
+ARG ELIXIR_VERSION=1.16.0
+ARG OTP_VERSION=26.2.1
+ARG DEBIAN_VERSION=bullseye-20231009-slim
 
 ARG BUILDER_IMAGE="hexpm/elixir:${ELIXIR_VERSION}-erlang-${OTP_VERSION}-debian-${DEBIAN_VERSION}"
 ARG RUNNER_IMAGE="debian:${DEBIAN_VERSION}"


### PR DESCRIPTION
# Problem

I updated the development environment Elixir and Erlang versions to 1.16.0 and 26.2.1 respectively in c9026c310f7fd093f6a1e37183908a5ac4720023. Unfortunately I forgot to also update the github workflow that tests this project to use these versions and also forgot to update the Dockerfile which we use for building the project for deployment. This put the project in the bad position of development happening in different versions than the CI/CD pipeline.

# Solution

I've updated the relevant github action and Dockerfile to use the appropriate versions.