### PR TITLE
Restrict viewing blog post by role

### DIFF
--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -72,7 +72,7 @@ defmodule Tqm.Blog do
   def list_blog_posts(:all), do: Repo.all(BlogPost)
 
   @doc """
-  Gets a single blog_post.
+  Gets a single blog_post according to publication status.
 
   Raises `Ecto.NoResultsError` if the Blog post does not exist.
 
@@ -84,8 +84,25 @@ defmodule Tqm.Blog do
       iex> get_blog_post!(456)
       ** (Ecto.NoResultsError)
 
+      iex> get_blog_post!(:published, 111)
+      ** (Ecto.NoResultsError)
+
+      iex> get_blog_post!(:all, 111)
+      %BlogPost{}
+
   """
-  def get_blog_post!(id), do: Repo.get!(BlogPost, id)
+  def get_blog_post!(id), do: get_blog_post!(:published, id)
+
+  def get_blog_post!(:published, id) do
+    time_now = NaiveDateTime.utc_now()
+
+    Repo.one!(
+      from bp in BlogPost,
+        where: bp.id == ^id and bp.published_at <= ^time_now and not is_nil(bp.published_at)
+    )
+  end
+
+  def get_blog_post!(:all, id), do: Repo.get!(BlogPost, id)
 
   @doc """
   Creates a blog_post.

--- a/lib/tqm_web/controllers/blog_post_controller.ex
+++ b/lib/tqm_web/controllers/blog_post_controller.ex
@@ -31,7 +31,11 @@ defmodule TqmWeb.BlogPostController do
   end
 
   def show(conn, %{"id" => id}) do
-    blog_post = Blog.get_blog_post!(id)
+    blog_post =
+      conn.assigns[:current_person]
+      |> Blog.viewing_permissions_for_person()
+      |> Blog.get_blog_post!(id)
+
     render(conn, :show, blog_post: blog_post, tlp: :blog)
   end
 

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -48,9 +48,35 @@ defmodule Tqm.BlogTest do
       assert Blog.list_blog_posts(:published) == [blog_post]
     end
 
-    test "get_blog_post!/1 returns the blog_post with given id" do
-      blog_post = blog_post_fixture()
-      assert Blog.get_blog_post!(blog_post.id) == blog_post
+    test "get_blog_post!/1 returns only published blog_posts" do
+      published_blog_post = blog_post_fixture()
+      unpublished_blog_post = unpublished_blog_post_fixture()
+      future_blog_post = future_blog_post_fixture()
+
+      assert Blog.get_blog_post!(published_blog_post.id) == published_blog_post
+      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(unpublished_blog_post.id) end
+      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(future_blog_post.id) end
+    end
+
+    test "get_blog_post!/2 returns based on permissions" do
+      published_blog_post = blog_post_fixture()
+      unpublished_blog_post = unpublished_blog_post_fixture()
+      future_blog_post = future_blog_post_fixture()
+
+      assert Blog.get_blog_post!(:published, published_blog_post.id) == published_blog_post
+      assert Blog.get_blog_post!(:all, published_blog_post.id) == published_blog_post
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Blog.get_blog_post!(:published, unpublished_blog_post.id)
+      end
+
+      assert Blog.get_blog_post!(:all, unpublished_blog_post.id) == unpublished_blog_post
+
+      assert_raise Ecto.NoResultsError, fn ->
+        Blog.get_blog_post!(:published, future_blog_post.id)
+      end
+
+      assert Blog.get_blog_post!(:all, future_blog_post.id) == future_blog_post
     end
 
     test "create_blog_post/1 with valid data creates a blog_post" do

--- a/test/tqm_web/controllers/blog_post_controller_test.exs
+++ b/test/tqm_web/controllers/blog_post_controller_test.exs
@@ -23,6 +23,34 @@ defmodule TqmWeb.BlogPostControllerTest do
     end
   end
 
+  describe "show" do
+    test "show a blog_post", %{conn: conn} do
+      blog_post = blog_post_fixture()
+      conn = get(conn, ~p"/blog/#{blog_post.id}")
+      assert html_response(conn, 200) =~ blog_post.content
+    end
+
+    test "show unpublished blog_post for owner person", %{conn: conn} do
+      unpublished_blog_post = unpublished_blog_post_fixture()
+
+      conn =
+        conn
+        |> log_in_person(owner_person_fixture())
+        |> get(~p"/blog/#{unpublished_blog_post.id}")
+
+      assert html_response(conn, 200) =~ unpublished_blog_post.content
+    end
+
+    test "show 404 for unpublished blog_post for non owner", %{conn: conn} do
+      unpublished_blog_post = unpublished_blog_post_fixture()
+      assert_error_sent(404, fn -> get(conn, ~p"/blog/#{unpublished_blog_post.id}") end)
+    end
+
+    test "show 404 for non-existant blog_post", %{conn: conn} do
+      assert_error_sent(404, fn -> get(conn, ~p"/blog/0") end)
+    end
+  end
+
   describe "new blog_post" do
     test "renders form", %{conn: conn} do
       conn =


### PR DESCRIPTION
The URL for viewing a blog post is `/blog/{id}`, which is all fine and dandy sugar candy. The issue is that unpublished and future published blog posts have IDs which thus made them also accessible, by anyone. We want to control who can view unpublished and future published blog posts, which at this time is only "owners". The work in this PR makes it such that non owners trying to access a blog post that is unpublished or future published results in a 404, and looks exactly the same as trying to access a blog post which does not exist at all.