### PR TITLE
Increase Fly machine memory to 512mb

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,6 +12,11 @@ processes = []
   PHX_HOST = "quigleymalcolm.com"
   PORT = "8080"
 
+[vm]
+  memory = '512mb'
+  cpu_kind = 'shared'
+  cpus = 1
+
 [experimental]
   auto_rollback = true
 


### PR DESCRIPTION
OTP 28 has a higher baseline memory footprint than OTP 26, causing the BEAM VM to be OOM killed on the default 256mb machine size.