### PR TITLE
Update blog post reading experience

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -2,10 +2,23 @@
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
 
+div.markdown_render h1 { font-size: 1.875rem; font-weight: 700; margin: 1rem 0; }
+div.markdown_render h2 { font-size: 1.5rem;   font-weight: 700; margin: 1rem 0; }
+div.markdown_render h3 { font-size: 1.25rem;  font-weight: 600; margin: 0.75rem 0; }
+div.markdown_render h4 { font-size: 1.125rem; font-weight: 600; margin: 0.75rem 0; }
+div.markdown_render h5 { font-size: 1rem;     font-weight: 600; margin: 0.5rem 0; }
+div.markdown_render h6 { font-size: 0.875rem; font-weight: 600; margin: 0.5rem 0; }
+
+div.markdown_render p { margin: 0.75rem 0; }
+
 div.markdown_render ul > li {
     margin-left: 15px;
     list-style-type: initial;
+}
 
+div.markdown_render ol > li {
+    margin-left: 15px;
+    list-style-type: decimal;
 }
 
 div.markdown_render a {

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -21,6 +21,36 @@ div.markdown_render ol > li {
     list-style-type: decimal;
 }
 
+div.markdown_render blockquote {
+    border-left: 4px solid #d1d5db;
+    margin: 1rem 0;
+    padding: 0.25rem 0 0.25rem 1rem;
+    color: #6b7280;
+}
+
+div.markdown_render code {
+    font-family: ui-monospace, monospace;
+    font-size: 0.875em;
+    background-color: #f3f4f6;
+    padding: 0.125rem 0.25rem;
+    border-radius: 0.25rem;
+}
+
+div.markdown_render pre {
+    background-color: #f3f4f6;
+    border-radius: 0.375rem;
+    padding: 1rem;
+    margin: 1rem 0;
+    overflow-x: auto;
+}
+
+div.markdown_render pre > code {
+    background-color: transparent;
+    padding: 0;
+    border-radius: 0;
+    font-size: 0.875rem;
+}
+
 div.markdown_render a {
     color: #0000EE;
     text-decoration: underline;

--- a/lib/tqm_web/controllers/blog_post_html/index.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/index.html.heex
@@ -1,9 +1,9 @@
 <.header>
-  Listing Blog posts
+  Blog
   <:actions>
     <%= if Tqm.Accounts.Person.owner?(assigns[:current_person]) do %>
       <.link href={~p"/blog/new"}>
-        <.button>New Blog post</.button>
+        <.button>New post</.button>
       </.link>
     <% end %>
   </:actions>

--- a/lib/tqm_web/controllers/blog_post_html/index.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/index.html.heex
@@ -11,8 +11,11 @@
 
 <.table id="blog_posts" rows={@blog_posts} row_click={&JS.navigate(~p"/blog/#{&1}")}>
   <:col :let={blog_post} label="Title">{blog_post.title}</:col>
-  <:col :let={blog_post} label="Content">{blog_post.content}</:col>
-  <:col :let={blog_post} label="Published at">{blog_post.published_at}</:col>
+  <:col :let={blog_post} label="Published">
+    {if blog_post.published_at,
+      do: Calendar.strftime(blog_post.published_at, "%B %-d, %Y"),
+      else: "Draft"}
+  </:col>
   <:action :let={blog_post}>
     <div class="sr-only">
       <.link navigate={~p"/blog/#{blog_post}"}>Show</.link>

--- a/lib/tqm_web/controllers/blog_post_html/show.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/show.html.heex
@@ -1,18 +1,19 @@
-<.header>
-  {@blog_post.title}
-  <:actions>
-    <%= if Tqm.Accounts.Person.owner?(assigns[:current_person]) do %>
-      <.link href={~p"/blog/#{@blog_post}/edit"}>
-        <.button>Edit</.button>
-      </.link>
-    <% end %>
-  </:actions>
-</.header>
+<div class="max-w-2xl mx-auto">
+  <.header>
+    {@blog_post.title}
+    <:subtitle :if={@blog_post.published_at}>
+      {Calendar.strftime(@blog_post.published_at, "%B %-d, %Y")}
+    </:subtitle>
+    <:actions>
+      <%= if Tqm.Accounts.Person.owner?(assigns[:current_person]) do %>
+        <.link href={~p"/blog/#{@blog_post}/edit"}>
+          <.button>Edit</.button>
+        </.link>
+      <% end %>
+    </:actions>
+  </.header>
 
-<.list>
-  <:item title="Published at">{@blog_post.published_at}</:item>
-</.list>
+  <.markdown_content markdown={@blog_post.content} />
 
-<.markdown_content markdown={@blog_post.content} />
-
-<.back navigate={~p"/blog"}>Back to blog</.back>
+  <.back navigate={~p"/blog"}>Back to blog</.back>
+</div>

--- a/lib/tqm_web/controllers/blog_post_html/show.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/show.html.heex
@@ -1,10 +1,9 @@
 <.header>
-  Blog post {@blog_post.id}
-  <:subtitle>This is a blog_post record from your database.</:subtitle>
+  {@blog_post.title}
   <:actions>
     <%= if Tqm.Accounts.Person.owner?(assigns[:current_person]) do %>
       <.link href={~p"/blog/#{@blog_post}/edit"}>
-        <.button>Edit blog_post</.button>
+        <.button>Edit</.button>
       </.link>
     <% end %>
   </:actions>
@@ -16,4 +15,4 @@
   <:item title="Published at">{@blog_post.published_at}</:item>
 </.list>
 
-<.back navigate={~p"/blog"}>Back to blog_posts</.back>
+<.back navigate={~p"/blog"}>Back to blog</.back>

--- a/lib/tqm_web/controllers/blog_post_html/show.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/show.html.heex
@@ -10,9 +10,9 @@
 </.header>
 
 <.list>
-  <:item title="Title">{@blog_post.title}</:item>
-  <:item title="Content">{@blog_post.content}</:item>
   <:item title="Published at">{@blog_post.published_at}</:item>
 </.list>
+
+<.markdown_content markdown={@blog_post.content} />
 
 <.back navigate={~p"/blog"}>Back to blog</.back>

--- a/test/tqm_web/controllers/blog_post_controller_test.exs
+++ b/test/tqm_web/controllers/blog_post_controller_test.exs
@@ -19,7 +19,7 @@ defmodule TqmWeb.BlogPostControllerTest do
   describe "index" do
     test "lists all blog_posts", %{conn: conn} do
       conn = get(conn, ~p"/blog")
-      assert html_response(conn, 200) =~ "Listing Blog posts"
+      assert html_response(conn, 200) =~ "Blog"
     end
   end
 
@@ -95,7 +95,7 @@ defmodule TqmWeb.BlogPostControllerTest do
       assert redirected_to(conn) == ~p"/blog/#{id}"
 
       conn = get(conn, ~p"/blog/#{id}")
-      assert html_response(conn, 200) =~ "Blog post #{id}"
+      assert html_response(conn, 200) =~ @create_attrs.title
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
  ## Summary

  - Replaces scaffold copy throughout the show and index pages (post title
    as the heading, "Blog" as the index heading, formatted dates, back link
    copy, button labels)
  - Renders blog post content as markdown via Earmark on the show page,
    replacing the raw label-value field
  - Restructures the show page layout for reading: max-width prose container,
    published date as a formatted subtitle, content flowing naturally below
    the header
  - Improves the index page: removes the raw content column, replaces the
    raw Published at timestamp with a formatted date, shows "Draft" for
    unpublished posts
  - Adds CSS for markdown elements that Tailwind's base reset strips:
    headings (h1–h6), ordered lists, paragraphs, blockquotes, inline code,
    and code blocks (with overflow scrolling for long lines)
