### PR TITLE
Add RSS feed at /blog/feed.xml

### DIFF
--- a/lib/tqm_web/components/layouts/app.html.heex
+++ b/lib/tqm_web/components/layouts/app.html.heex
@@ -1,19 +1,24 @@
-<.navbar tlp={assigns[:tlp]} current_person={@current_person} />
-<main class={if assigns[:page_padding] == nil or assigns[:page_padding], do: "px-4 py-4"}>
-  <div class="mx-auto">
-    <.flash kind={:info} title="Success!" flash={@flash} />
-    <.flash kind={:error} title="Error!" flash={@flash} />
-    <.flash
-      id="disconnected"
-      kind={:error}
-      title="We can't find the internet"
-      close={false}
-      autoshow={false}
-      phx-disconnected={show("#disconnected")}
-      phx-connected={hide("#disconnected")}
-    >
-      Attempting to reconnect <Heroicons.arrow_path class="ml-1 w-3 h-3 inline animate-spin" />
-    </.flash>
-    {@inner_content}
-  </div>
-</main>
+<div class="flex flex-col min-h-screen">
+  <.navbar tlp={assigns[:tlp]} current_person={@current_person} />
+  <main class={"flex-1 #{if assigns[:page_padding] == nil or assigns[:page_padding], do: "px-4 py-4"}"}>
+    <div class="mx-auto">
+      <.flash kind={:info} title="Success!" flash={@flash} />
+      <.flash kind={:error} title="Error!" flash={@flash} />
+      <.flash
+        id="disconnected"
+        kind={:error}
+        title="We can't find the internet"
+        close={false}
+        autoshow={false}
+        phx-disconnected={show("#disconnected")}
+        phx-connected={hide("#disconnected")}
+      >
+        Attempting to reconnect <Heroicons.arrow_path class="ml-1 w-3 h-3 inline animate-spin" />
+      </.flash>
+      {@inner_content}
+    </div>
+  </main>
+  <footer class="bg-pink-900 text-white px-3 py-3">
+    <.link navigate={~p"/blog/feed.xml"} class="text-sm hover:underline">RSS</.link>
+  </footer>
+</div>

--- a/lib/tqm_web/components/layouts/root.html.heex
+++ b/lib/tqm_web/components/layouts/root.html.heex
@@ -8,6 +8,12 @@
       {assigns[:page_title] || "Quigley Malcolm"}
     </.live_title>
     <link rel="icon" type="image/png" href={~p"/favicon.png"} />
+    <link
+      rel="alternate"
+      type="application/rss+xml"
+      title="Quigley Malcolm"
+      href={~p"/blog/feed.xml"}
+    />
     <link phx-track-static rel="stylesheet" href={~p"/assets/app.css"} />
     <script defer phx-track-static type="text/javascript" src={~p"/assets/app.js"}>
     </script>

--- a/lib/tqm_web/controllers/feed_controller.ex
+++ b/lib/tqm_web/controllers/feed_controller.ex
@@ -1,0 +1,58 @@
+defmodule TqmWeb.FeedController do
+  use TqmWeb, :controller
+
+  alias Tqm.Blog
+
+  def index(conn, _params) do
+    blog_posts =
+      Blog.list_blog_posts(:published)
+      |> Enum.sort_by(& &1.published_at, {:desc, DateTime})
+
+    conn
+    |> put_resp_content_type("application/rss+xml")
+    |> send_resp(200, rss_feed(blog_posts))
+  end
+
+  defp rss_feed(blog_posts) do
+    base_url = TqmWeb.Endpoint.url()
+
+    items =
+      Enum.map_join(blog_posts, fn post ->
+        """
+            <item>
+              <title>#{xml_escape(post.title)}</title>
+              <link>#{base_url}/blog/#{post.id}</link>
+              <guid>#{base_url}/blog/#{post.id}</guid>
+              <pubDate>#{rss_date(post.published_at)}</pubDate>
+              <description><![CDATA[#{post.content}]]></description>
+            </item>
+        """
+      end)
+
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+      <channel>
+        <title>Quigley Malcolm</title>
+        <link>#{base_url}</link>
+        <description>Blog posts by Quigley Malcolm</description>
+        <atom:link href="#{base_url}/blog/feed.xml" rel="self" type="application/rss+xml"/>
+        #{items}
+      </channel>
+    </rss>
+    """
+  end
+
+  defp rss_date(datetime) do
+    Calendar.strftime(datetime, "%a, %d %b %Y %H:%M:%S +0000")
+  end
+
+  defp xml_escape(str) do
+    str
+    |> String.replace("&", "&amp;")
+    |> String.replace("<", "&lt;")
+    |> String.replace(">", "&gt;")
+    |> String.replace("\"", "&quot;")
+    |> String.replace("'", "&apos;")
+  end
+end

--- a/lib/tqm_web/router.ex
+++ b/lib/tqm_web/router.ex
@@ -29,6 +29,11 @@ defmodule TqmWeb.Router do
     end
   end
 
+  ## Feed routes (no pipeline — public, no session or CSRF needed)
+  scope "/", TqmWeb do
+    get "/blog/feed.xml", FeedController, :index
+  end
+
   ## Unauthed routes
   scope "/", TqmWeb do
     pipe_through :browser

--- a/test/tqm_web/controllers/feed_controller_test.exs
+++ b/test/tqm_web/controllers/feed_controller_test.exs
@@ -1,0 +1,28 @@
+defmodule TqmWeb.FeedControllerTest do
+  use TqmWeb.ConnCase, async: true
+
+  import Tqm.BlogFixtures
+
+  describe "index" do
+    test "returns an RSS feed with published posts", %{conn: conn} do
+      blog_post = blog_post_fixture()
+      conn = get(conn, ~p"/blog/feed.xml")
+
+      assert response(conn, 200) =~ "<?xml"
+      assert List.first(get_resp_header(conn, "content-type")) =~ "application/rss+xml"
+      assert response(conn, 200) =~ blog_post.title
+    end
+
+    test "excludes unpublished posts", %{conn: conn} do
+      unpublished = unpublished_blog_post_fixture()
+      conn = get(conn, ~p"/blog/feed.xml")
+      refute response(conn, 200) =~ unpublished.title
+    end
+
+    test "excludes future-scheduled posts", %{conn: conn} do
+      future = future_blog_post_fixture()
+      conn = get(conn, ~p"/blog/feed.xml")
+      refute response(conn, 200) =~ future.title
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `GET /blog/feed.xml` serving an RSS 2.0 feed of published blog posts, sorted newest-first
- Feed route uses no pipeline (no session, CSRF, or format negotiation needed for a public XML endpoint)
- Adds `<link rel="alternate">` to the root layout for auto-discovery by browsers and feed readers

## Test plan

- [x] `mix test` passes (3 new feed controller tests covering published posts, unpublished exclusion, and future-scheduled exclusion)
- [x] Navigate to `/blog/feed.xml` in a browser and confirm valid XML is returned
- [x] Paste the blog URL into an RSS reader and confirm it auto-discovers the feed