### PR TITLE
Add blog post tagging with filtered RSS feeds

### DIFF
--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -8,6 +8,7 @@ defmodule Tqm.Blog do
 
   alias Tqm.Accounts.Person
   alias Tqm.Blog.BlogPost
+  alias Tqm.Blog.Tag
 
   @doc """
   Returns an atom denoting blog_post viewing permissions a person has.
@@ -39,13 +40,13 @@ defmodule Tqm.Blog do
   end
 
   @doc """
-  Returns an unpaginated list of blog_posts.
+  Returns an unpaginated list of blog_posts with tags preloaded.
 
-  Optionally an atom: `:published` and `:all`. The default value is
-  `:published`, which will only return blog_posts that have a `published_at`
-  value that is in the past. Passing `:all` will return all blog_posts which
-  includes published blog_posts as well as blog_posts with a `published_at`
-  of `nil` or a future date.
+  Accepts a visibility atom (`:published` or `:all`) and an optional
+  keyword list. Supported opts:
+
+    * `:tag` — a tag slug string; when provided only posts tagged with
+      that slug are returned.
 
   ## Examples
 
@@ -58,21 +59,38 @@ defmodule Tqm.Blog do
       iex> list_blog_posts(:all)
       [%BlogPost{}, %BlogPost{published_at: nil}, ...]
 
+      iex> list_blog_posts(:published, tag: "elixir")
+      [%BlogPost{}, ...]
+
   """
-  def list_blog_posts(), do: list_blog_posts(:published)
+  def list_blog_posts(visibility \\ :published, opts \\ [])
 
-  def list_blog_posts(:published) do
+  def list_blog_posts(:published, opts) do
     time_now = NaiveDateTime.utc_now()
+    tag_slug = Keyword.get(opts, :tag)
 
-    Repo.all(
-      from bp in BlogPost, where: bp.published_at <= ^time_now and not is_nil(bp.published_at)
-    )
+    base =
+      from bp in BlogPost,
+        where: bp.published_at <= ^time_now and not is_nil(bp.published_at)
+
+    query =
+      if tag_slug do
+        from bp in base,
+          join: t in assoc(bp, :tags),
+          where: t.slug == ^tag_slug
+      else
+        base
+      end
+
+    Repo.all(from bp in query, preload: :tags)
   end
 
-  def list_blog_posts(:all), do: Repo.all(BlogPost)
+  def list_blog_posts(:all, _opts) do
+    Repo.all(from bp in BlogPost, preload: :tags)
+  end
 
   @doc """
-  Gets a single blog_post according to publication status.
+  Gets a single blog_post with tags preloaded.
 
   Raises `Ecto.NoResultsError` if the Blog post does not exist.
 
@@ -100,9 +118,42 @@ defmodule Tqm.Blog do
       from bp in BlogPost,
         where: bp.id == ^id and bp.published_at <= ^time_now and not is_nil(bp.published_at)
     )
+    |> Repo.preload(:tags)
   end
 
-  def get_blog_post!(:all, id), do: Repo.get!(BlogPost, id)
+  def get_blog_post!(:all, id) do
+    Repo.get!(BlogPost, id)
+    |> Repo.preload(:tags)
+  end
+
+  @doc """
+  Returns all tags sorted by name.
+  """
+  def list_tags do
+    Repo.all(from t in Tag, order_by: t.name)
+  end
+
+  @doc """
+  Returns the tag with the given slug, or nil if none exists.
+  """
+  def get_tag_by_slug(slug), do: Repo.get_by(Tag, slug: slug)
+
+  @doc """
+  Finds an existing tag by slug or creates a new one from the given name.
+  """
+  def get_or_create_tag(name) do
+    slug = Tag.slugify(name)
+
+    case Repo.get_by(Tag, slug: slug) do
+      nil ->
+        %Tag{}
+        |> Tag.changeset(%{name: name})
+        |> Repo.insert()
+
+      tag ->
+        {:ok, tag}
+    end
+  end
 
   @doc """
   Creates a blog_post.
@@ -117,13 +168,20 @@ defmodule Tqm.Blog do
 
   """
   def create_blog_post(attrs \\ %{}) do
+    tags = resolve_tags(attrs)
+
     %BlogPost{}
     |> BlogPost.changeset(attrs)
+    |> Ecto.Changeset.put_assoc(:tags, tags)
     |> Repo.insert()
   end
 
   @doc """
   Updates a blog_post.
+
+  When `:tag_names` is present in `attrs` the post's tags are replaced with
+  the resolved tag list. When `:tag_names` is absent the existing tags are
+  left unchanged.
 
   ## Examples
 
@@ -135,9 +193,17 @@ defmodule Tqm.Blog do
 
   """
   def update_blog_post(%BlogPost{} = blog_post, attrs) do
-    blog_post
-    |> BlogPost.changeset(attrs)
-    |> Repo.update()
+    blog_post = Repo.preload(blog_post, :tags)
+
+    changeset = BlogPost.changeset(blog_post, attrs)
+
+    changeset =
+      case attrs[:tag_names] || attrs["tag_names"] do
+        nil -> changeset
+        _raw -> Ecto.Changeset.put_assoc(changeset, :tags, resolve_tags(attrs))
+      end
+
+    Repo.update(changeset)
   end
 
   @doc """
@@ -159,6 +225,9 @@ defmodule Tqm.Blog do
   @doc """
   Returns an `%Ecto.Changeset{}` for tracking blog_post changes.
 
+  Populates the virtual `:tag_names` field from the loaded tags association
+  when tags are preloaded, so the form reflects the current tag state.
+
   ## Examples
 
       iex> change_blog_post(blog_post)
@@ -166,6 +235,30 @@ defmodule Tqm.Blog do
 
   """
   def change_blog_post(%BlogPost{} = blog_post, attrs \\ %{}) do
-    BlogPost.changeset(blog_post, attrs)
+    blog_post
+    |> maybe_set_tag_names()
+    |> BlogPost.changeset(attrs)
+  end
+
+  # Populates :tag_names from the loaded tags so form inputs reflect
+  # the current state when editing. A no-op when tags are not loaded.
+  defp maybe_set_tag_names(%BlogPost{tags: %Ecto.Association.NotLoaded{}} = post), do: post
+
+  defp maybe_set_tag_names(%BlogPost{tags: tags} = post) do
+    %{post | tag_names: Enum.map_join(tags, ", ", & &1.name)}
+  end
+
+  # Parses the tag_names string from attrs into a list of Tag structs,
+  # finding or creating each tag. Returns [] when tag_names is absent.
+  defp resolve_tags(attrs) do
+    (attrs[:tag_names] || attrs["tag_names"] || "")
+    |> String.split(",")
+    |> Enum.map(&String.trim/1)
+    |> Enum.reject(&(&1 == ""))
+    |> Enum.uniq_by(&Tag.slugify/1)
+    |> Enum.map(fn name ->
+      {:ok, tag} = get_or_create_tag(name)
+      tag
+    end)
   end
 end

--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -85,8 +85,19 @@ defmodule Tqm.Blog do
     Repo.all(from bp in query, preload: :tags)
   end
 
-  def list_blog_posts(:all, _opts) do
-    Repo.all(from bp in BlogPost, preload: :tags)
+  def list_blog_posts(:all, opts) do
+    tag_slug = Keyword.get(opts, :tag)
+
+    query =
+      if tag_slug do
+        from bp in BlogPost,
+          join: t in assoc(bp, :tags),
+          where: t.slug == ^tag_slug
+      else
+        from(bp in BlogPost)
+      end
+
+    Repo.all(from bp in query, preload: :tags)
   end
 
   @doc """

--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -134,6 +134,17 @@ defmodule Tqm.Blog do
   end
 
   @doc """
+  Returns tags whose names partially match `term`, case-insensitively.
+  Returns an empty list when `term` is blank.
+  """
+  def search_tags(""), do: []
+
+  def search_tags(term) do
+    pattern = "%#{term}%"
+    Repo.all(from t in Tag, where: ilike(t.name, ^pattern), order_by: t.name)
+  end
+
+  @doc """
   Returns the tag with the given slug, or nil if none exists.
   """
   def get_tag_by_slug(slug), do: Repo.get_by(Tag, slug: slug)

--- a/lib/tqm/blog/blog_post.ex
+++ b/lib/tqm/blog/blog_post.ex
@@ -7,6 +7,9 @@ defmodule Tqm.Blog.BlogPost do
     field :content, :string
     field :published_at, :utc_datetime
     field :title, :string
+    field :tag_names, :string, virtual: true
+
+    many_to_many :tags, Tqm.Blog.Tag, join_through: "blog_post_tags", on_replace: :delete
 
     timestamps()
   end
@@ -14,7 +17,7 @@ defmodule Tqm.Blog.BlogPost do
   @doc false
   def changeset(blog_post, attrs) do
     blog_post
-    |> cast(attrs, [:title, :content, :published_at])
+    |> cast(attrs, [:title, :content, :published_at, :tag_names])
     |> validate_required([:title, :content])
   end
 end

--- a/lib/tqm/blog/tag.ex
+++ b/lib/tqm/blog/tag.ex
@@ -1,0 +1,60 @@
+defmodule Tqm.Blog.Tag do
+  @moduledoc false
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "tags" do
+    field :name, :string
+    field :slug, :string
+
+    many_to_many :blog_posts, Tqm.Blog.BlogPost, join_through: "blog_post_tags"
+
+    timestamps()
+  end
+
+  def changeset(tag, attrs) do
+    tag
+    |> cast(attrs, [:name])
+    |> validate_required([:name])
+    |> validate_format(:name, ~r/^[a-zA-Z0-9][a-zA-Z0-9 -]*$/,
+      message: "only letters, numbers, spaces, and hyphens allowed"
+    )
+    |> validate_length(:name, max: 50)
+    |> put_slug()
+    |> unique_constraint(:name)
+    |> unique_constraint(:slug)
+  end
+
+  @doc """
+  Derives a URL-safe slug from a tag name.
+
+  Lowercases, replaces whitespace runs with a single hyphen, and strips
+  any characters that are not alphanumeric or hyphens.
+
+  ## Examples
+
+      iex> Tqm.Blog.Tag.slugify("Elixir")
+      "elixir"
+
+      iex> Tqm.Blog.Tag.slugify("Machine Learning")
+      "machine-learning"
+
+      iex> Tqm.Blog.Tag.slugify("C++")
+      "c"
+
+  """
+  def slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/\s+/, "-")
+    |> String.replace(~r/[^a-z0-9-]/, "")
+    |> String.trim("-")
+  end
+
+  defp put_slug(changeset) do
+    case get_change(changeset, :name) do
+      nil -> changeset
+      name -> put_change(changeset, :slug, slugify(name))
+    end
+  end
+end

--- a/lib/tqm_web/controllers/blog_post_controller.ex
+++ b/lib/tqm_web/controllers/blog_post_controller.ex
@@ -9,7 +9,25 @@ defmodule TqmWeb.BlogPostController do
       |> Blog.viewing_permissions_for_person()
       |> Blog.list_blog_posts()
 
-    render(conn, :index, tlp: :blog, blog_posts: blog_posts, page_title: "Blog")
+    render(conn, :index,
+      tlp: :blog,
+      blog_posts: blog_posts,
+      page_title: "Blog",
+      current_tag: nil
+    )
+  end
+
+  def tag(conn, %{"tag" => slug}) do
+    visibility = conn.assigns[:current_person] |> Blog.viewing_permissions_for_person()
+    blog_posts = Blog.list_blog_posts(visibility, tag: slug)
+    current_tag = Blog.get_tag_by_slug(slug)
+
+    render(conn, :index,
+      tlp: :blog,
+      blog_posts: blog_posts,
+      page_title: if(current_tag, do: "#{current_tag.name} posts", else: "#{slug} posts"),
+      current_tag: current_tag
+    )
   end
 
   def show(conn, %{"id" => id}) do

--- a/lib/tqm_web/controllers/blog_post_html/index.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/index.html.heex
@@ -9,12 +9,30 @@
   </:actions>
 </.header>
 
+<p :if={@current_tag} class="mt-2 text-sm text-zinc-600">
+  Posts tagged "<span class="font-medium">{@current_tag.name}</span>"
+  &mdash;
+  <.link navigate={~p"/blog"} class="underline hover:text-zinc-900">all posts</.link>
+</p>
+
 <.table id="blog_posts" rows={@blog_posts} row_click={&JS.navigate(~p"/blog/#{&1}")}>
   <:col :let={blog_post} label="Title">{blog_post.title}</:col>
   <:col :let={blog_post} label="Published">
     {if blog_post.published_at,
       do: Calendar.strftime(blog_post.published_at, "%B %-d, %Y"),
       else: "Draft"}
+  </:col>
+  <:col :let={blog_post} label="Tags">
+    <div class="flex flex-wrap gap-1">
+      <%= for tag <- blog_post.tags do %>
+        <.link
+          navigate={~p"/blog/tags/#{tag.slug}"}
+          class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 hover:bg-zinc-200"
+        >
+          {tag.name}
+        </.link>
+      <% end %>
+    </div>
   </:col>
   <:action :let={blog_post}>
     <div class="sr-only">

--- a/lib/tqm_web/controllers/blog_post_html/index.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/index.html.heex
@@ -11,8 +11,7 @@
 
 <p :if={@current_tag} class="mt-2 text-sm text-zinc-600">
   Posts tagged "<span class="font-medium">{@current_tag.name}</span>"
-  &mdash;
-  <.link navigate={~p"/blog"} class="underline hover:text-zinc-900">all posts</.link>
+  &mdash; <.link navigate={~p"/blog"} class="underline hover:text-zinc-900">all posts</.link>
 </p>
 
 <.table id="blog_posts" rows={@blog_posts} row_click={&JS.navigate(~p"/blog/#{&1}")}>

--- a/lib/tqm_web/controllers/blog_post_html/show.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/show.html.heex
@@ -13,6 +13,17 @@
     </:actions>
   </.header>
 
+  <div :if={@blog_post.tags != []} class="mt-2 flex flex-wrap gap-1">
+    <%= for tag <- @blog_post.tags do %>
+      <.link
+        navigate={~p"/blog/tags/#{tag.slug}"}
+        class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 hover:bg-zinc-200"
+      >
+        {tag.name}
+      </.link>
+    <% end %>
+  </div>
+
   <.markdown_content markdown={@blog_post.content} />
 
   <.back navigate={~p"/blog"}>Back to blog</.back>

--- a/lib/tqm_web/controllers/feed_controller.ex
+++ b/lib/tqm_web/controllers/feed_controller.ex
@@ -4,28 +4,46 @@ defmodule TqmWeb.FeedController do
   alias Tqm.Blog
 
   def index(conn, _params) do
+    base_url = TqmWeb.Endpoint.url()
+
     blog_posts =
       Blog.list_blog_posts(:published)
       |> Enum.sort_by(& &1.published_at, {:desc, DateTime})
 
+    channel = %{
+      title: "Quigley Malcolm",
+      description: "Blog posts by Quigley Malcolm",
+      self_link: "#{base_url}/blog/feed.xml"
+    }
+
     conn
     |> put_resp_content_type("application/rss+xml")
-    |> send_resp(200, rss_feed(blog_posts))
+    |> send_resp(200, build_rss(channel, blog_posts, base_url))
   end
 
   def tag(conn, %{"tag" => slug}) do
+    base_url = TqmWeb.Endpoint.url()
+
     blog_posts =
       Blog.list_blog_posts(:published, tag: slug)
       |> Enum.sort_by(& &1.published_at, {:desc, DateTime})
 
+    channel = %{
+      title: "Quigley Malcolm - #{xml_escape(slug)} posts",
+      description: "Blog posts tagged &#34;#{xml_escape(slug)}&#34; by Quigley Malcolm",
+      self_link: "#{base_url}/blog/tags/#{slug}/feed.xml"
+    }
+
     conn
     |> put_resp_content_type("application/rss+xml")
-    |> send_resp(200, tag_rss_feed(blog_posts, slug))
+    |> send_resp(200, build_rss(channel, blog_posts, base_url))
   end
 
-  defp rss_feed(blog_posts) do
-    base_url = TqmWeb.Endpoint.url()
-
+  defp build_rss(
+         %{title: title, description: description, self_link: self_link},
+         blog_posts,
+         base_url
+       ) do
     items =
       Enum.map_join(blog_posts, fn post ->
         """
@@ -44,41 +62,10 @@ defmodule TqmWeb.FeedController do
     <?xml version="1.0" encoding="UTF-8"?>
     <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
       <channel>
-        <title>Quigley Malcolm</title>
+        <title>#{title}</title>
         <link>#{base_url}</link>
-        <description>Blog posts by Quigley Malcolm</description>
-        <atom:link href="#{base_url}/blog/feed.xml" rel="self" type="application/rss+xml"/>
-        #{items}
-      </channel>
-    </rss>
-    """
-  end
-
-  defp tag_rss_feed(blog_posts, slug) do
-    base_url = TqmWeb.Endpoint.url()
-
-    items =
-      Enum.map_join(blog_posts, fn post ->
-        """
-            <item>
-              <title>#{xml_escape(post.title)}</title>
-              <link>#{base_url}/blog/#{post.id}</link>
-              <guid>#{base_url}/blog/#{post.id}</guid>
-              <pubDate>#{rss_date(post.published_at)}</pubDate>
-              <description><![CDATA[#{post.content}]]></description>
-              #{tag_categories(post)}
-            </item>
-        """
-      end)
-
-    """
-    <?xml version="1.0" encoding="UTF-8"?>
-    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
-      <channel>
-        <title>Quigley Malcolm - #{xml_escape(slug)} posts</title>
-        <link>#{base_url}</link>
-        <description>Blog posts tagged &#34;#{xml_escape(slug)}&#34; by Quigley Malcolm</description>
-        <atom:link href="#{base_url}/blog/tags/#{slug}/feed.xml" rel="self" type="application/rss+xml"/>
+        <description>#{description}</description>
+        <atom:link href="#{self_link}" rel="self" type="application/rss+xml"/>
         #{items}
       </channel>
     </rss>

--- a/lib/tqm_web/controllers/feed_controller.ex
+++ b/lib/tqm_web/controllers/feed_controller.ex
@@ -13,6 +13,16 @@ defmodule TqmWeb.FeedController do
     |> send_resp(200, rss_feed(blog_posts))
   end
 
+  def tag(conn, %{"tag" => slug}) do
+    blog_posts =
+      Blog.list_blog_posts(:published, tag: slug)
+      |> Enum.sort_by(& &1.published_at, {:desc, DateTime})
+
+    conn
+    |> put_resp_content_type("application/rss+xml")
+    |> send_resp(200, tag_rss_feed(blog_posts, slug))
+  end
+
   defp rss_feed(blog_posts) do
     base_url = TqmWeb.Endpoint.url()
 
@@ -25,6 +35,7 @@ defmodule TqmWeb.FeedController do
               <guid>#{base_url}/blog/#{post.id}</guid>
               <pubDate>#{rss_date(post.published_at)}</pubDate>
               <description><![CDATA[#{post.content}]]></description>
+              #{tag_categories(post)}
             </item>
         """
       end)
@@ -41,6 +52,43 @@ defmodule TqmWeb.FeedController do
       </channel>
     </rss>
     """
+  end
+
+  defp tag_rss_feed(blog_posts, slug) do
+    base_url = TqmWeb.Endpoint.url()
+
+    items =
+      Enum.map_join(blog_posts, fn post ->
+        """
+            <item>
+              <title>#{xml_escape(post.title)}</title>
+              <link>#{base_url}/blog/#{post.id}</link>
+              <guid>#{base_url}/blog/#{post.id}</guid>
+              <pubDate>#{rss_date(post.published_at)}</pubDate>
+              <description><![CDATA[#{post.content}]]></description>
+              #{tag_categories(post)}
+            </item>
+        """
+      end)
+
+    """
+    <?xml version="1.0" encoding="UTF-8"?>
+    <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+      <channel>
+        <title>Quigley Malcolm - #{xml_escape(slug)} posts</title>
+        <link>#{base_url}</link>
+        <description>Blog posts tagged &#34;#{xml_escape(slug)}&#34; by Quigley Malcolm</description>
+        <atom:link href="#{base_url}/blog/tags/#{slug}/feed.xml" rel="self" type="application/rss+xml"/>
+        #{items}
+      </channel>
+    </rss>
+    """
+  end
+
+  defp tag_categories(post) do
+    Enum.map_join(post.tags, "\n", fn tag ->
+      "          <category>#{xml_escape(tag.name)}</category>"
+    end)
   end
 
   defp rss_date(datetime) do

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -12,7 +12,10 @@ defmodule TqmWeb.BlogPostLive.Form do
        tlp: :blog,
        scheduling: false,
        publish_status: :draft,
-       available_tags: []
+       selected_tag_names: [],
+       tag_search: "",
+       tag_suggestions: [],
+       tag_create_option: nil
      )}
   end
 
@@ -25,7 +28,7 @@ defmodule TqmWeb.BlogPostLive.Form do
      assign(socket,
        blog_post: blog_post,
        changeset: changeset,
-       available_tags: Blog.list_tags(),
+       selected_tag_names: Enum.map(blog_post.tags, & &1.name),
        publish_status: publish_status(blog_post),
        page_title: "Edit post"
      )}
@@ -38,7 +41,6 @@ defmodule TqmWeb.BlogPostLive.Form do
      assign(socket,
        blog_post: %BlogPost{},
        changeset: changeset,
-       available_tags: Blog.list_tags(),
        page_title: "New post"
      )}
   end
@@ -49,42 +51,80 @@ defmodule TqmWeb.BlogPostLive.Form do
   end
 
   def handle_event("validate", %{"blog_post" => params}, socket) do
+    tag_names = Enum.join(socket.assigns.selected_tag_names, ", ")
+
     changeset =
       socket.assigns.blog_post
-      |> Blog.change_blog_post(params)
+      |> Blog.change_blog_post(Map.put(params, "tag_names", tag_names))
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, changeset: changeset)}
   end
 
   def handle_event("save", %{"blog_post" => params}, socket) do
-    save_blog_post(socket, socket.assigns.live_action, params)
+    tag_names = Enum.join(socket.assigns.selected_tag_names, ", ")
+    save_blog_post(socket, socket.assigns.live_action, Map.put(params, "tag_names", tag_names))
   end
 
-  def handle_event("add_tag", %{"tag" => tag_name}, socket) do
-    current = Ecto.Changeset.get_field(socket.assigns.changeset, :tag_names) || ""
+  def handle_event("search_tags", %{"tag_search" => term}, socket) do
+    term = String.trim(term)
+    all_suggestions = Blog.search_tags(term)
 
-    existing =
-      current
-      |> String.split(",")
-      |> Enum.map(&String.trim/1)
-      |> Enum.reject(&(&1 == ""))
+    exact_match_exists =
+      Enum.any?(all_suggestions, fn t ->
+        String.downcase(t.name) == String.downcase(term)
+      end)
 
-    new_names =
-      if tag_name in existing,
-        do: current,
-        else: (existing ++ [tag_name]) |> Enum.join(", ")
+    selected_lower = Enum.map(socket.assigns.selected_tag_names, &String.downcase/1)
 
-    changeset =
-      socket.assigns.blog_post
-      |> Blog.change_blog_post(%{"tag_names" => new_names})
-      |> Map.put(:action, :validate)
+    filtered =
+      Enum.reject(all_suggestions, fn t ->
+        String.downcase(t.name) in selected_lower
+      end)
 
-    {:noreply, assign(socket, changeset: changeset)}
+    create_option =
+      if term != "" and not exact_match_exists, do: term, else: nil
+
+    {:noreply,
+     assign(socket,
+       tag_search: term,
+       tag_suggestions: filtered,
+       tag_create_option: create_option
+     )}
+  end
+
+  def handle_event("select_tag", %{"name" => name}, socket) do
+    name = String.trim(name)
+    selected = socket.assigns.selected_tag_names
+    selected_lower = Enum.map(selected, &String.downcase/1)
+
+    new_selected =
+      if String.downcase(name) in selected_lower,
+        do: selected,
+        else: selected ++ [name]
+
+    {:noreply,
+     assign(socket,
+       selected_tag_names: new_selected,
+       tag_search: "",
+       tag_suggestions: [],
+       tag_create_option: nil
+     )}
+  end
+
+  def handle_event("remove_tag", %{"name" => name}, socket) do
+    new_selected =
+      Enum.reject(socket.assigns.selected_tag_names, fn n ->
+        String.downcase(n) == String.downcase(name)
+      end)
+
+    {:noreply, assign(socket, selected_tag_names: new_selected)}
   end
 
   def handle_event("publish_now", _params, socket) do
-    attrs = current_attrs(socket.assigns.changeset) |> Map.put(:published_at, DateTime.utc_now())
+    attrs =
+      current_attrs(socket.assigns.changeset, socket.assigns.selected_tag_names)
+      |> Map.put(:published_at, DateTime.utc_now())
 
     case Blog.update_blog_post(socket.assigns.blog_post, attrs) do
       {:ok, blog_post} ->
@@ -110,7 +150,10 @@ defmodule TqmWeb.BlogPostLive.Form do
     case NaiveDateTime.from_iso8601(scheduled_at_str <> ":00") do
       {:ok, naive_dt} ->
         {:ok, utc_dt} = DateTime.from_naive(naive_dt, "Etc/UTC")
-        attrs = current_attrs(socket.assigns.changeset) |> Map.put(:published_at, utc_dt)
+
+        attrs =
+          current_attrs(socket.assigns.changeset, socket.assigns.selected_tag_names)
+          |> Map.put(:published_at, utc_dt)
 
         case Blog.update_blog_post(socket.assigns.blog_post, attrs) do
           {:ok, blog_post} ->
@@ -154,9 +197,14 @@ defmodule TqmWeb.BlogPostLive.Form do
     end
   end
 
-  defp current_attrs(changeset) do
+  defp current_attrs(changeset, selected_tag_names) do
     current = Ecto.Changeset.apply_changes(changeset)
-    %{title: current.title, content: current.content, tag_names: current.tag_names}
+
+    %{
+      title: current.title,
+      content: current.content,
+      tag_names: Enum.join(selected_tag_names, ", ")
+    }
   end
 
   defp publish_status(%{published_at: nil}), do: :draft

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -6,7 +6,14 @@ defmodule TqmWeb.BlogPostLive.Form do
 
   @impl true
   def mount(_params, _session, socket) do
-    {:ok, assign(socket, mode: :write, tlp: :blog, scheduling: false, publish_status: :draft)}
+    {:ok,
+     assign(socket,
+       mode: :write,
+       tlp: :blog,
+       scheduling: false,
+       publish_status: :draft,
+       available_tags: []
+     )}
   end
 
   @impl true
@@ -18,6 +25,7 @@ defmodule TqmWeb.BlogPostLive.Form do
      assign(socket,
        blog_post: blog_post,
        changeset: changeset,
+       available_tags: Blog.list_tags(),
        publish_status: publish_status(blog_post),
        page_title: "Edit post"
      )}
@@ -27,7 +35,12 @@ defmodule TqmWeb.BlogPostLive.Form do
     changeset = Blog.change_blog_post(%BlogPost{})
 
     {:noreply,
-     assign(socket, blog_post: %BlogPost{}, changeset: changeset, page_title: "New post")}
+     assign(socket,
+       blog_post: %BlogPost{},
+       changeset: changeset,
+       available_tags: Blog.list_tags(),
+       page_title: "New post"
+     )}
   end
 
   @impl true
@@ -46,6 +59,28 @@ defmodule TqmWeb.BlogPostLive.Form do
 
   def handle_event("save", %{"blog_post" => params}, socket) do
     save_blog_post(socket, socket.assigns.live_action, params)
+  end
+
+  def handle_event("add_tag", %{"tag" => tag_name}, socket) do
+    current = Ecto.Changeset.get_field(socket.assigns.changeset, :tag_names) || ""
+
+    existing =
+      current
+      |> String.split(",")
+      |> Enum.map(&String.trim/1)
+      |> Enum.reject(&(&1 == ""))
+
+    new_names =
+      if tag_name in existing,
+        do: current,
+        else: (existing ++ [tag_name]) |> Enum.join(", ")
+
+    changeset =
+      socket.assigns.blog_post
+      |> Blog.change_blog_post(%{"tag_names" => new_names})
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, changeset: changeset)}
   end
 
   def handle_event("publish_now", _params, socket) do
@@ -121,7 +156,7 @@ defmodule TqmWeb.BlogPostLive.Form do
 
   defp current_attrs(changeset) do
     current = Ecto.Changeset.apply_changes(changeset)
-    %{title: current.title, content: current.content}
+    %{title: current.title, content: current.content, tag_names: current.tag_names}
   end
 
   defp publish_status(%{published_at: nil}), do: :draft

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -66,7 +66,7 @@ defmodule TqmWeb.BlogPostLive.Form do
     save_blog_post(socket, socket.assigns.live_action, Map.put(params, "tag_names", tag_names))
   end
 
-  def handle_event("search_tags", %{"tag_search" => term}, socket) do
+  def handle_event("search_tags", %{"value" => term}, socket) do
     term = String.trim(term)
     all_suggestions = Blog.search_tags(term)
 

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -32,23 +32,64 @@
     </.error>
     <.input field={{f, :title}} type="text" label="Title" />
     <.input field={{f, :content}} type="textarea" label="Content" />
-    <.input
-      field={{f, :tag_names}}
-      type="text"
-      label="Tags"
-      placeholder="e.g. elixir, phoenix"
-    />
-    <div :if={@available_tags != []} class="mt-1 flex flex-wrap gap-1">
-      <%= for tag <- @available_tags do %>
-        <button
-          type="button"
-          phx-click="add_tag"
-          phx-value-tag={tag.name}
-          class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 hover:bg-zinc-200"
+    <div>
+      <label class="block text-sm font-semibold leading-6 text-zinc-900">Tags</label>
+      <div :if={@selected_tag_names != []} class="mt-2 flex flex-wrap gap-1.5">
+        <%= for name <- @selected_tag_names do %>
+          <span class="inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700">
+            {name}
+            <button
+              type="button"
+              phx-click="remove_tag"
+              phx-value-name={name}
+              aria-label={"Remove #{name}"}
+              class="ml-0.5 rounded-full p-0.5 text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600"
+            >
+              <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true">
+                <path d="M6.414 5l3.293-3.293a1 1 0 00-1.414-1.414L5 3.586 1.707.293A1 1 0 00.293 1.707L3.586 5 .293 8.293a1 1 0 101.414 1.414L5 6.414l3.293 3.293a1 1 0 001.414-1.414L6.414 5z" />
+              </svg>
+            </button>
+          </span>
+        <% end %>
+      </div>
+      <div class="relative mt-2">
+        <input
+          type="text"
+          name="tag_search"
+          value={@tag_search}
+          phx-keyup="search_tags"
+          phx-debounce="200"
+          placeholder="Search tags..."
+          autocomplete="off"
+          class="block w-full rounded-lg border border-zinc-300 py-[7px] px-[11px] text-zinc-900 focus:border-zinc-400 focus:outline-none focus:ring-4 focus:ring-zinc-800/5 sm:text-sm sm:leading-6"
+        />
+        <ul
+          :if={@tag_suggestions != [] or @tag_create_option != nil}
+          class="absolute z-10 mt-1 w-full rounded-md border border-zinc-200 bg-white py-1 shadow-lg text-sm text-zinc-700"
         >
-          {tag.name}
-        </button>
-      <% end %>
+          <li :for={tag <- @tag_suggestions}>
+            <button
+              type="button"
+              phx-click="select_tag"
+              phx-value-name={tag.name}
+              class="w-full px-4 py-2 text-left hover:bg-zinc-50"
+            >
+              {tag.name}
+            </button>
+          </li>
+          <li :if={@tag_create_option != nil}>
+            <button
+              type="button"
+              phx-click="select_tag"
+              phx-value-name={@tag_create_option}
+              class="w-full px-4 py-2 text-left hover:bg-zinc-50"
+            >
+              {@tag_create_option}
+              <span class="text-zinc-400">(create new)</span>
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
     <:actions>
       <div class="flex flex-wrap items-center gap-3">

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -32,6 +32,24 @@
     </.error>
     <.input field={{f, :title}} type="text" label="Title" />
     <.input field={{f, :content}} type="textarea" label="Content" />
+    <.input
+      field={{f, :tag_names}}
+      type="text"
+      label="Tags"
+      placeholder="e.g. elixir, phoenix"
+    />
+    <div :if={@available_tags != []} class="mt-1 flex flex-wrap gap-1">
+      <%= for tag <- @available_tags do %>
+        <button
+          type="button"
+          phx-click="add_tag"
+          phx-value-tag={tag.name}
+          class="rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600 hover:bg-zinc-200"
+        >
+          {tag.name}
+        </button>
+      <% end %>
+    </div>
     <:actions>
       <div class="flex flex-wrap items-center gap-3">
         <.button>Save</.button>

--- a/lib/tqm_web/router.ex
+++ b/lib/tqm_web/router.ex
@@ -40,6 +40,7 @@ defmodule TqmWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :home
+    get "/blog/tags/:tag", BlogPostController, :tag
     resources "/blog", BlogPostController, only: [:index, :show]
   end
 

--- a/lib/tqm_web/router.ex
+++ b/lib/tqm_web/router.ex
@@ -32,6 +32,7 @@ defmodule TqmWeb.Router do
   ## Feed routes (no pipeline — public, no session or CSRF needed)
   scope "/", TqmWeb do
     get "/blog/feed.xml", FeedController, :index
+    get "/blog/tags/:tag/feed.xml", FeedController, :tag
   end
 
   ## Unauthed routes

--- a/priv/repo/migrations/20260503202433_create_tags.exs
+++ b/priv/repo/migrations/20260503202433_create_tags.exs
@@ -1,0 +1,15 @@
+defmodule Tqm.Repo.Migrations.CreateTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:tags) do
+      add :name, :string, null: false
+      add :slug, :string, null: false
+
+      timestamps()
+    end
+
+    create unique_index(:tags, [:name])
+    create unique_index(:tags, [:slug])
+  end
+end

--- a/priv/repo/migrations/20260503202435_create_blog_post_tags.exs
+++ b/priv/repo/migrations/20260503202435_create_blog_post_tags.exs
@@ -1,0 +1,14 @@
+defmodule Tqm.Repo.Migrations.CreateBlogPostTags do
+  use Ecto.Migration
+
+  def change do
+    create table(:blog_post_tags, primary_key: false) do
+      add :blog_post_id, references(:blog_posts, on_delete: :delete_all), null: false
+      add :tag_id, references(:tags, on_delete: :delete_all), null: false
+    end
+
+    create index(:blog_post_tags, [:blog_post_id])
+    create index(:blog_post_tags, [:tag_id])
+    create unique_index(:blog_post_tags, [:blog_post_id, :tag_id])
+  end
+end

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -48,6 +48,20 @@ defmodule Tqm.BlogTest do
       assert Blog.list_blog_posts(:published) == [blog_post]
     end
 
+    test "list_blog_posts/2 filters by tag slug" do
+      elixir_post = blog_post_fixture(%{tag_names: "Elixir", title: "elixir post"})
+      _other_post = blog_post_fixture(%{tag_names: "gardening", title: "gardening post"})
+
+      result = Blog.list_blog_posts(:published, tag: "elixir")
+      assert length(result) == 1
+      assert hd(result).id == elixir_post.id
+    end
+
+    test "list_blog_posts/2 returns empty list for unknown tag" do
+      blog_post_fixture()
+      assert Blog.list_blog_posts(:published, tag: "nonexistent") == []
+    end
+
     test "get_blog_post!/1 returns only published blog_posts" do
       published_blog_post = blog_post_fixture()
       unpublished_blog_post = unpublished_blog_post_fixture()
@@ -95,6 +109,26 @@ defmodule Tqm.BlogTest do
       assert {:error, %Ecto.Changeset{}} = Blog.create_blog_post(@invalid_attrs)
     end
 
+    test "create_blog_post/1 creates and associates tags" do
+      assert {:ok, %BlogPost{} = post} =
+               Blog.create_blog_post(
+                 Map.put(@published_valid_attrs, :tag_names, "Elixir, Phoenix")
+               )
+
+      assert [%{name: "Elixir", slug: "elixir"}, %{name: "Phoenix", slug: "phoenix"}] =
+               Enum.sort_by(post.tags, & &1.name)
+    end
+
+    test "create_blog_post/1 reuses existing tags" do
+      Blog.get_or_create_tag("Elixir")
+
+      assert {:ok, post} =
+               Blog.create_blog_post(Map.put(@published_valid_attrs, :tag_names, "Elixir"))
+
+      assert length(post.tags) == 1
+      assert length(Blog.list_tags()) == 1
+    end
+
     test "update_blog_post/2 with valid data updates the blog_post" do
       blog_post = blog_post_fixture()
 
@@ -116,6 +150,18 @@ defmodule Tqm.BlogTest do
       assert blog_post == Blog.get_blog_post!(blog_post.id)
     end
 
+    test "update_blog_post/2 replaces tags when tag_names provided" do
+      post = blog_post_fixture(%{tag_names: "Elixir"})
+      assert {:ok, updated} = Blog.update_blog_post(post, %{tag_names: "Phoenix"})
+      assert [%{slug: "phoenix"}] = updated.tags
+    end
+
+    test "update_blog_post/2 preserves tags when tag_names absent" do
+      post = blog_post_fixture(%{tag_names: "Elixir"})
+      assert {:ok, updated} = Blog.update_blog_post(post, %{title: "New title"})
+      assert [%{slug: "elixir"}] = updated.tags
+    end
+
     test "delete_blog_post/1 deletes the blog_post" do
       blog_post = blog_post_fixture()
       assert {:ok, %BlogPost{}} = Blog.delete_blog_post(blog_post)
@@ -125,6 +171,50 @@ defmodule Tqm.BlogTest do
     test "change_blog_post/1 returns a blog_post changeset" do
       blog_post = blog_post_fixture()
       assert %Ecto.Changeset{} = Blog.change_blog_post(blog_post)
+    end
+
+    test "change_blog_post/1 populates tag_names from loaded tags" do
+      post = blog_post_fixture(%{tag_names: "Elixir, Phoenix"})
+      changeset = Blog.change_blog_post(post)
+      tag_names = Ecto.Changeset.get_field(changeset, :tag_names)
+      assert tag_names =~ "Elixir"
+      assert tag_names =~ "Phoenix"
+    end
+  end
+
+  describe "tags" do
+    alias Tqm.Blog.Tag
+
+    test "get_or_create_tag/1 creates a new tag" do
+      assert {:ok, %Tag{name: "Elixir", slug: "elixir"}} = Blog.get_or_create_tag("Elixir")
+    end
+
+    test "get_or_create_tag/1 returns existing tag on duplicate slug" do
+      {:ok, tag} = Blog.get_or_create_tag("Elixir")
+      assert {:ok, ^tag} = Blog.get_or_create_tag("Elixir")
+      assert length(Blog.list_tags()) == 1
+    end
+
+    test "list_tags/0 returns tags sorted by name" do
+      {:ok, _} = Blog.get_or_create_tag("Phoenix")
+      {:ok, _} = Blog.get_or_create_tag("Elixir")
+      names = Blog.list_tags() |> Enum.map(& &1.name)
+      assert names == ["Elixir", "Phoenix"]
+    end
+
+    test "get_tag_by_slug/1 returns matching tag" do
+      {:ok, tag} = Blog.get_or_create_tag("Elixir")
+      assert Blog.get_tag_by_slug("elixir") == tag
+    end
+
+    test "get_tag_by_slug/1 returns nil for unknown slug" do
+      assert Blog.get_tag_by_slug("nonexistent") == nil
+    end
+
+    test "Tag.slugify/1 normalizes names to URL-safe slugs" do
+      assert Tag.slugify("Elixir") == "elixir"
+      assert Tag.slugify("Machine Learning") == "machine-learning"
+      assert Tag.slugify("C++") == "c"
     end
   end
 end

--- a/test/tqm_web/controllers/feed_controller_test.exs
+++ b/test/tqm_web/controllers/feed_controller_test.exs
@@ -24,5 +24,45 @@ defmodule TqmWeb.FeedControllerTest do
       conn = get(conn, ~p"/blog/feed.xml")
       refute response(conn, 200) =~ future.title
     end
+
+    test "includes category elements for tagged posts", %{conn: conn} do
+      blog_post_fixture(%{tag_names: "Elixir"})
+      conn = get(conn, ~p"/blog/feed.xml")
+      assert response(conn, 200) =~ "<category>Elixir</category>"
+    end
+  end
+
+  describe "tag" do
+    test "returns an RSS feed filtered to the given tag", %{conn: conn} do
+      tagged = blog_post_fixture(%{tag_names: "Elixir", title: "tagged post"})
+      untagged = blog_post_fixture(%{title: "untagged post"})
+
+      conn = get(conn, ~p"/blog/tags/elixir/feed.xml")
+
+      body = response(conn, 200)
+      assert body =~ "<?xml"
+      assert List.first(get_resp_header(conn, "content-type")) =~ "application/rss+xml"
+      assert body =~ tagged.title
+      refute body =~ untagged.title
+    end
+
+    test "self-link points to the tag feed URL", %{conn: conn} do
+      conn = get(conn, ~p"/blog/tags/elixir/feed.xml")
+      assert response(conn, 200) =~ "/blog/tags/elixir/feed.xml"
+    end
+
+    test "returns empty feed for unknown tag", %{conn: conn} do
+      blog_post_fixture()
+      conn = get(conn, ~p"/blog/tags/nonexistent/feed.xml")
+      body = response(conn, 200)
+      assert body =~ "<?xml"
+      refute body =~ "<item>"
+    end
+
+    test "excludes unpublished posts even for matching tag", %{conn: conn} do
+      unpublished = unpublished_blog_post_fixture(%{tag_names: "Elixir"})
+      conn = get(conn, ~p"/blog/tags/elixir/feed.xml")
+      refute response(conn, 200) =~ unpublished.title
+    end
   end
 end


### PR DESCRIPTION
## Summary

- Adds a \`tags\` table and \`blog_post_tags\` join table with cascade deletes in both directions
- Tags store both a display name and a pre-computed URL-safe slug; normalization happens at write time
- \`Blog\` context gains \`list_tags/0\`, \`search_tags/1\`, \`get_or_create_tag/1\`, \`get_tag_by_slug/1\`, and an optional \`tag:\` slug filter on \`list_blog_posts/2\`
- Tag-filtered RSS feed at \`/blog/tags/:tag/feed.xml\`; main feed and tag feeds both include \`<category>\` elements
- Post form has an interactive tag picker: type to search existing tags (case-insensitive partial match), select a suggestion or create a new tag, and remove selected tags via pill × buttons
- Tags render as chips on the index and show pages, linking to filtered listings at \`/blog/tags/:tag\`

## Test plan

- [x] Create a new post — type in the tag search box, verify matching existing tags appear as suggestions
- [x] Select an existing tag suggestion — pill appears, search clears, dropdown closes
- [x] Type a term with no exact case-insensitive match — \`(create new)\` option appears; selecting it creates the tag on save
- [x] Type a term that exactly matches an existing tag name (different casing) — no \`(create new)\` shown
- [x] Click \`×\` on a pill to remove a tag
- [x] Edit an existing post — tags are pre-populated as pills
- [x] Verify tags appear on the post listing and show page
- [x] Click a tag chip to reach the filtered listing; verify only tagged posts appear
- [x] Subscribe to \`/blog/tags/:tag/feed.xml\` and confirm only matching posts appear
- [x] Confirm \`/blog/feed.xml\` still works and now includes \`<category>\` elements for tagged posts
- [x] Edit an existing post and change its tags; confirm the filtered feed reflects the update
- [x] Visit \`/blog/tags/nonexistent/feed.xml\`; confirm a valid empty RSS feed is returned