### PR TITLE
Add Phoenix.CodeReloader listener to mix.exs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Tqm.MixProject do
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
+      listeners: [Phoenix.CodeReloader],
       aliases: aliases(),
       deps: deps()
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,7 @@ defmodule Tqm.MixProject do
       elixir: "~> 1.14",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
-      listeners: [Phoenix.CodeReloader],
+      listeners: if(Mix.env() == :dev, do: [Phoenix.CodeReloader], else: []),
       aliases: aliases(),
       deps: deps()
     ]


### PR DESCRIPTION
## Summary

- Adds `listeners: [Phoenix.CodeReloader]` to `project/0` in `mix.exs`

Phoenix 1.8 requires this to hook the code reloader into Mix compilation events. Without it the dev server logs a warning on every file change.

## Test plan

- [ ] Start the dev server and edit a source file — confirm no `Mix listener expected by Phoenix.CodeReloader is missing` warning in the logs