### PR TITLE
Route blog posts by slug instead of id

### DIFF
--- a/lib/tqm/blog.ex
+++ b/lib/tqm/blog.ex
@@ -107,33 +107,33 @@ defmodule Tqm.Blog do
 
   ## Examples
 
-      iex> get_blog_post!(123)
+      iex> get_blog_post!("my-post")
       %BlogPost{}
 
-      iex> get_blog_post!(456)
+      iex> get_blog_post!("nonexistent")
       ** (Ecto.NoResultsError)
 
-      iex> get_blog_post!(:published, 111)
+      iex> get_blog_post!(:published, "draft-post")
       ** (Ecto.NoResultsError)
 
-      iex> get_blog_post!(:all, 111)
+      iex> get_blog_post!(:all, "draft-post")
       %BlogPost{}
 
   """
-  def get_blog_post!(id), do: get_blog_post!(:published, id)
+  def get_blog_post!(slug), do: get_blog_post!(:published, slug)
 
-  def get_blog_post!(:published, id) do
+  def get_blog_post!(:published, slug) do
     time_now = NaiveDateTime.utc_now()
 
     Repo.one!(
       from bp in BlogPost,
-        where: bp.id == ^id and bp.published_at <= ^time_now and not is_nil(bp.published_at)
+        where: bp.slug == ^slug and bp.published_at <= ^time_now and not is_nil(bp.published_at)
     )
     |> Repo.preload(:tags)
   end
 
-  def get_blog_post!(:all, id) do
-    Repo.get!(BlogPost, id)
+  def get_blog_post!(:all, slug) do
+    Repo.get_by!(BlogPost, slug: slug)
     |> Repo.preload(:tags)
   end
 

--- a/lib/tqm/blog/blog_post.ex
+++ b/lib/tqm/blog/blog_post.ex
@@ -48,6 +48,11 @@ defmodule Tqm.Blog.BlogPost do
     |> String.trim("-")
   end
 
+  defimpl Phoenix.Param do
+    def to_param(%{slug: slug}) when is_binary(slug), do: slug
+    def to_param(%{id: id}), do: to_string(id)
+  end
+
   # Sets slug from title only when the post doesn't already have one.
   # Slug is immutable after creation so that published URLs don't change on title edits.
   defp maybe_put_slug(changeset) do

--- a/lib/tqm/blog/blog_post.ex
+++ b/lib/tqm/blog/blog_post.ex
@@ -7,6 +7,7 @@ defmodule Tqm.Blog.BlogPost do
     field :content, :string
     field :published_at, :utc_datetime
     field :title, :string
+    field :slug, :string
     field :tag_names, :string, virtual: true
 
     many_to_many :tags, Tqm.Blog.Tag, join_through: "blog_post_tags", on_replace: :delete
@@ -19,5 +20,46 @@ defmodule Tqm.Blog.BlogPost do
     blog_post
     |> cast(attrs, [:title, :content, :published_at, :tag_names])
     |> validate_required([:title, :content])
+    |> maybe_put_slug()
+    |> validate_exclusion(:slug, ~w(new), message: "is reserved — choose a different title")
+    |> unique_constraint(:slug)
+  end
+
+  @doc """
+  Derives a URL-safe slug from a string.
+
+  ## Examples
+
+      iex> Tqm.Blog.BlogPost.slugify("My First Post")
+      "my-first-post"
+
+      iex> Tqm.Blog.BlogPost.slugify("Hello, World!")
+      "hello-world"
+
+      iex> Tqm.Blog.BlogPost.slugify("C++")
+      "c"
+
+  """
+  def slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/\s+/, "-")
+    |> String.replace(~r/[^a-z0-9-]/, "")
+    |> String.trim("-")
+  end
+
+  # Sets slug from title only when the post doesn't already have one.
+  # Slug is immutable after creation so that published URLs don't change on title edits.
+  defp maybe_put_slug(changeset) do
+    case get_field(changeset, :slug) do
+      nil ->
+        case get_change(changeset, :title) do
+          nil -> changeset
+          title -> put_change(changeset, :slug, slugify(title))
+        end
+
+      _slug ->
+        changeset
+    end
   end
 end

--- a/lib/tqm/blog/blog_post.ex
+++ b/lib/tqm/blog/blog_post.ex
@@ -18,7 +18,7 @@ defmodule Tqm.Blog.BlogPost do
   @doc false
   def changeset(blog_post, attrs) do
     blog_post
-    |> cast(attrs, [:title, :content, :published_at, :tag_names])
+    |> cast(attrs, [:title, :content, :published_at, :tag_names, :slug])
     |> validate_required([:title, :content])
     |> maybe_put_slug()
     |> validate_exclusion(:slug, ~w(new), message: "is reserved — choose a different title")

--- a/lib/tqm_web/controllers/blog_post_controller.ex
+++ b/lib/tqm_web/controllers/blog_post_controller.ex
@@ -30,17 +30,17 @@ defmodule TqmWeb.BlogPostController do
     )
   end
 
-  def show(conn, %{"id" => id}) do
+  def show(conn, %{"slug" => slug}) do
     blog_post =
       conn.assigns[:current_person]
       |> Blog.viewing_permissions_for_person()
-      |> Blog.get_blog_post!(id)
+      |> Blog.get_blog_post!(slug)
 
     render(conn, :show, blog_post: blog_post, tlp: :blog, page_title: blog_post.title)
   end
 
-  def delete(conn, %{"id" => id}) do
-    blog_post = Blog.get_blog_post!(id)
+  def delete(conn, %{"slug" => slug}) do
+    blog_post = Blog.get_blog_post!(slug)
     {:ok, _blog_post} = Blog.delete_blog_post(blog_post)
 
     conn

--- a/lib/tqm_web/controllers/feed_controller.ex
+++ b/lib/tqm_web/controllers/feed_controller.ex
@@ -49,8 +49,8 @@ defmodule TqmWeb.FeedController do
         """
             <item>
               <title>#{xml_escape(post.title)}</title>
-              <link>#{base_url}/blog/#{post.id}</link>
-              <guid>#{base_url}/blog/#{post.id}</guid>
+              <link>#{base_url}/blog/#{post.slug}</link>
+              <guid>#{base_url}/blog/#{post.slug}</guid>
               <pubDate>#{rss_date(post.published_at)}</pubDate>
               <description><![CDATA[#{post.content}]]></description>
               #{tag_categories(post)}

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -70,11 +70,19 @@ defmodule TqmWeb.BlogPostLive.Form do
   end
 
   def handle_event("lock_slug", %{"blog_post" => params}, socket) do
+    current = Ecto.Changeset.apply_changes(socket.assigns.changeset)
     tag_names = Enum.join(socket.assigns.selected_tag_names, ", ")
+
+    attrs = %{
+      "title" => current.title,
+      "content" => current.content,
+      "slug" => params["slug"],
+      "tag_names" => tag_names
+    }
 
     changeset =
       socket.assigns.blog_post
-      |> Blog.change_blog_post(Map.put(params, "tag_names", tag_names))
+      |> Blog.change_blog_post(attrs)
       |> Map.put(:action, :validate)
 
     {:noreply, assign(socket, slug_locked: true, changeset: changeset)}

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -20,8 +20,8 @@ defmodule TqmWeb.BlogPostLive.Form do
   end
 
   @impl true
-  def handle_params(%{"id" => id}, _url, socket) do
-    blog_post = Blog.get_blog_post!(:all, id)
+  def handle_params(%{"slug" => slug}, _url, socket) do
+    blog_post = Blog.get_blog_post!(:all, slug)
     changeset = Blog.change_blog_post(blog_post)
 
     {:noreply,

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -4,6 +4,8 @@ defmodule TqmWeb.BlogPostLive.Form do
   alias Tqm.Blog
   alias Tqm.Blog.BlogPost
 
+  import Tqm.Blog.BlogPost, only: [slugify: 1]
+
   @impl true
   def mount(_params, _session, socket) do
     {:ok,
@@ -12,6 +14,7 @@ defmodule TqmWeb.BlogPostLive.Form do
        tlp: :blog,
        scheduling: false,
        publish_status: :draft,
+       slug_locked: false,
        selected_tag_names: [],
        tag_search: "",
        tag_suggestions: [],
@@ -53,12 +56,28 @@ defmodule TqmWeb.BlogPostLive.Form do
   def handle_event("validate", %{"blog_post" => params}, socket) do
     tag_names = Enum.join(socket.assigns.selected_tag_names, ", ")
 
+    params =
+      params
+      |> Map.put("tag_names", tag_names)
+      |> maybe_inject_slug(socket)
+
+    changeset =
+      socket.assigns.blog_post
+      |> Blog.change_blog_post(params)
+      |> Map.put(:action, :validate)
+
+    {:noreply, assign(socket, changeset: changeset)}
+  end
+
+  def handle_event("lock_slug", %{"blog_post" => params}, socket) do
+    tag_names = Enum.join(socket.assigns.selected_tag_names, ", ")
+
     changeset =
       socket.assigns.blog_post
       |> Blog.change_blog_post(Map.put(params, "tag_names", tag_names))
       |> Map.put(:action, :validate)
 
-    {:noreply, assign(socket, changeset: changeset)}
+    {:noreply, assign(socket, slug_locked: true, changeset: changeset)}
   end
 
   def handle_event("save", %{"blog_post" => params}, socket) do
@@ -212,4 +231,11 @@ defmodule TqmWeb.BlogPostLive.Form do
   defp publish_status(%{published_at: published_at}) do
     if DateTime.compare(published_at, DateTime.utc_now()) == :gt, do: :scheduled, else: :published
   end
+
+  # Auto-populate slug from title for new posts until the user manually edits the slug field.
+  defp maybe_inject_slug(params, %{assigns: %{live_action: :new, slug_locked: false}}) do
+    Map.put(params, "slug", slugify(params["title"] || ""))
+  end
+
+  defp maybe_inject_slug(params, _socket), do: params
 end

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -31,6 +31,18 @@
       Oops, something went wrong! Please check the errors below.
     </.error>
     <.input field={{f, :title}} type="text" label="Title" />
+    <div :if={@live_action == :new}>
+      <.input
+        field={{f, :slug}}
+        type="text"
+        label="Slug"
+        phx-change="lock_slug"
+        phx-debounce="200"
+      />
+      <p :if={not @slug_locked} class="mt-1 text-xs text-zinc-400">
+        Auto-populated from title
+      </p>
+    </div>
     <.input field={{f, :content}} type="textarea" label="Content" />
     <div>
       <label class="block text-sm font-semibold leading-6 text-zinc-900">Tags</label>

--- a/lib/tqm_web/router.ex
+++ b/lib/tqm_web/router.ex
@@ -20,12 +20,12 @@ defmodule TqmWeb.Router do
   ## Routes requiring :owner person role
   scope "/", TqmWeb do
     pipe_through [:browser, :require_owner_person]
-    delete "/blog/:id", BlogPostController, :delete
+    delete "/blog/:slug", BlogPostController, :delete
 
     live_session :require_owner_person,
       on_mount: [{TqmWeb.PersonAuth, :ensure_owner}] do
       live "/blog/new", BlogPostLive.Form, :new
-      live "/blog/:id/edit", BlogPostLive.Form, :edit
+      live "/blog/:slug/edit", BlogPostLive.Form, :edit
     end
   end
 
@@ -41,7 +41,8 @@ defmodule TqmWeb.Router do
 
     get "/", PageController, :home
     get "/blog/tags/:tag", BlogPostController, :tag
-    resources "/blog", BlogPostController, only: [:index, :show]
+    get "/blog", BlogPostController, :index
+    get "/blog/:slug", BlogPostController, :show
   end
 
   # Other scopes may use custom stacks.

--- a/priv/repo/migrations/20260523120000_add_slug_to_blog_posts.exs
+++ b/priv/repo/migrations/20260523120000_add_slug_to_blog_posts.exs
@@ -1,0 +1,52 @@
+defmodule Tqm.Repo.Migrations.AddSlugToBlogPosts do
+  use Ecto.Migration
+
+  import Ecto.Query
+
+  def up do
+    alter table(:blog_posts) do
+      add :slug, :string
+    end
+
+    flush()
+
+    backfill_slugs()
+
+    execute "ALTER TABLE blog_posts ALTER COLUMN slug SET NOT NULL"
+
+    create unique_index(:blog_posts, [:slug])
+  end
+
+  def down do
+    drop unique_index(:blog_posts, [:slug])
+
+    alter table(:blog_posts) do
+      remove :slug
+    end
+  end
+
+  defp backfill_slugs do
+    posts = repo().all(from(p in "blog_posts", select: {p.id, p.title}))
+
+    Enum.reduce(posts, MapSet.new(), fn {id, title}, seen ->
+      base =
+        case slugify(title) do
+          "" -> "post-#{id}"
+          s -> s
+        end
+
+      slug = if MapSet.member?(seen, base), do: "#{base}-#{id}", else: base
+
+      repo().update_all(from(p in "blog_posts", where: p.id == ^id), set: [slug: slug])
+      MapSet.put(seen, slug)
+    end)
+  end
+
+  defp slugify(name) do
+    name
+    |> String.downcase()
+    |> String.replace(~r/\s+/, "-")
+    |> String.replace(~r/[^a-z0-9-]/, "")
+    |> String.trim("-")
+  end
+end

--- a/test/tqm/blog_test.exs
+++ b/test/tqm/blog_test.exs
@@ -67,9 +67,9 @@ defmodule Tqm.BlogTest do
       unpublished_blog_post = unpublished_blog_post_fixture()
       future_blog_post = future_blog_post_fixture()
 
-      assert Blog.get_blog_post!(published_blog_post.id) == published_blog_post
-      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(unpublished_blog_post.id) end
-      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(future_blog_post.id) end
+      assert Blog.get_blog_post!(published_blog_post.slug) == published_blog_post
+      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(unpublished_blog_post.slug) end
+      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(future_blog_post.slug) end
     end
 
     test "get_blog_post!/2 returns based on permissions" do
@@ -77,20 +77,20 @@ defmodule Tqm.BlogTest do
       unpublished_blog_post = unpublished_blog_post_fixture()
       future_blog_post = future_blog_post_fixture()
 
-      assert Blog.get_blog_post!(:published, published_blog_post.id) == published_blog_post
-      assert Blog.get_blog_post!(:all, published_blog_post.id) == published_blog_post
+      assert Blog.get_blog_post!(:published, published_blog_post.slug) == published_blog_post
+      assert Blog.get_blog_post!(:all, published_blog_post.slug) == published_blog_post
 
       assert_raise Ecto.NoResultsError, fn ->
-        Blog.get_blog_post!(:published, unpublished_blog_post.id)
+        Blog.get_blog_post!(:published, unpublished_blog_post.slug)
       end
 
-      assert Blog.get_blog_post!(:all, unpublished_blog_post.id) == unpublished_blog_post
+      assert Blog.get_blog_post!(:all, unpublished_blog_post.slug) == unpublished_blog_post
 
       assert_raise Ecto.NoResultsError, fn ->
-        Blog.get_blog_post!(:published, future_blog_post.id)
+        Blog.get_blog_post!(:published, future_blog_post.slug)
       end
 
-      assert Blog.get_blog_post!(:all, future_blog_post.id) == future_blog_post
+      assert Blog.get_blog_post!(:all, future_blog_post.slug) == future_blog_post
     end
 
     test "create_blog_post/1 with valid data creates a blog_post" do
@@ -98,11 +98,13 @@ defmodule Tqm.BlogTest do
       assert blog_post.content == @published_valid_attrs.content
       assert blog_post.published_at == @published_valid_attrs.published_at
       assert blog_post.title == @published_valid_attrs.title
+      assert blog_post.slug == "some-title"
 
       assert {:ok, %BlogPost{} = blog_post} = Blog.create_blog_post(@unpublished_valid_attrs)
       assert blog_post.content == @unpublished_valid_attrs.content
       assert blog_post.published_at == @unpublished_valid_attrs.published_at
       assert blog_post.title == @unpublished_valid_attrs.title
+      assert blog_post.slug == "post-i-want-to-do"
     end
 
     test "create_blog_post/1 with invalid data returns error changeset" do
@@ -147,7 +149,13 @@ defmodule Tqm.BlogTest do
     test "update_blog_post/2 with invalid data returns error changeset" do
       blog_post = blog_post_fixture()
       assert {:error, %Ecto.Changeset{}} = Blog.update_blog_post(blog_post, @invalid_attrs)
-      assert blog_post == Blog.get_blog_post!(blog_post.id)
+      assert blog_post == Blog.get_blog_post!(blog_post.slug)
+    end
+
+    test "update_blog_post/2 preserves slug when title changes" do
+      blog_post = blog_post_fixture()
+      assert {:ok, updated} = Blog.update_blog_post(blog_post, %{title: "Completely Different"})
+      assert updated.slug == blog_post.slug
     end
 
     test "update_blog_post/2 replaces tags when tag_names provided" do
@@ -165,7 +173,7 @@ defmodule Tqm.BlogTest do
     test "delete_blog_post/1 deletes the blog_post" do
       blog_post = blog_post_fixture()
       assert {:ok, %BlogPost{}} = Blog.delete_blog_post(blog_post)
-      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(blog_post.id) end
+      assert_raise Ecto.NoResultsError, fn -> Blog.get_blog_post!(blog_post.slug) end
     end
 
     test "change_blog_post/1 returns a blog_post changeset" do

--- a/test/tqm_web/controllers/blog_post_controller_test.exs
+++ b/test/tqm_web/controllers/blog_post_controller_test.exs
@@ -20,7 +20,7 @@ defmodule TqmWeb.BlogPostControllerTest do
   describe "show" do
     test "show a blog_post", %{conn: conn} do
       blog_post = blog_post_fixture()
-      conn = get(conn, ~p"/blog/#{blog_post.id}")
+      conn = get(conn, ~p"/blog/#{blog_post}")
       assert html_response(conn, 200) =~ blog_post.content
     end
 
@@ -30,18 +30,18 @@ defmodule TqmWeb.BlogPostControllerTest do
       conn =
         conn
         |> log_in_person(owner_person_fixture())
-        |> get(~p"/blog/#{unpublished_blog_post.id}")
+        |> get(~p"/blog/#{unpublished_blog_post}")
 
       assert html_response(conn, 200) =~ unpublished_blog_post.content
     end
 
     test "show 404 for unpublished blog_post for non owner", %{conn: conn} do
       unpublished_blog_post = unpublished_blog_post_fixture()
-      assert_error_sent(404, fn -> get(conn, ~p"/blog/#{unpublished_blog_post.id}") end)
+      assert_error_sent(404, fn -> get(conn, ~p"/blog/#{unpublished_blog_post}") end)
     end
 
     test "show 404 for non-existant blog_post", %{conn: conn} do
-      assert_error_sent(404, fn -> get(conn, ~p"/blog/0") end)
+      assert_error_sent(404, fn -> get(conn, ~p"/blog/nonexistent-post") end)
     end
   end
 

--- a/test/tqm_web/live/blog_post_live_test.exs
+++ b/test/tqm_web/live/blog_post_live_test.exs
@@ -40,8 +40,45 @@ defmodule TqmWeb.BlogPostLive.FormTest do
                |> form("#blog_post_form", blog_post: %{title: "My title", content: "My content"})
                |> render_submit()
 
-      assert path =~ ~p"/blog/"
+      assert path == ~p"/blog/my-title"
       assert html_response(get(owner_conn, path), 200) =~ "My title"
+    end
+
+    test "slug is auto-populated from title", %{conn: conn} do
+      {:ok, lv, _html} =
+        conn
+        |> log_in_person(owner_person_fixture())
+        |> live(~p"/blog/new")
+
+      html =
+        lv
+        |> form("#blog_post_form", blog_post: %{title: "My Elixir Post"})
+        |> render_change()
+
+      assert html =~ ~s(value="my-elixir-post")
+      assert html =~ "Auto-populated from title"
+    end
+
+    test "manually editing slug locks it from further title changes", %{conn: conn} do
+      {:ok, lv, _html} =
+        conn
+        |> log_in_person(owner_person_fixture())
+        |> live(~p"/blog/new")
+
+      # Simulate user manually editing the slug field (fires lock_slug event)
+      lv
+      |> render_hook("lock_slug", %{
+        "blog_post" => %{"title" => "My Post", "slug" => "custom-slug", "content" => ""}
+      })
+
+      # Subsequent title change should not override the manually set slug
+      html =
+        lv
+        |> form("#blog_post_form", blog_post: %{title: "Completely Different Title"})
+        |> render_change()
+
+      assert html =~ ~s(value="custom-slug")
+      refute html =~ "Auto-populated from title"
     end
 
     test "renders errors when data is invalid", %{conn: conn} do


### PR DESCRIPTION
## Summary

- Adds a `slug` column to `blog_posts`, auto-derived from the title on creation and immutable thereafter (so published URLs don't change on title edits)
- Migration backfills slugs for existing posts, appending `-{id}` when two titles produce the same slug
- Implements `Phoenix.Param` for `BlogPost` so all `~p"/blog/#{post}"` helpers automatically produce slug-based URLs — template changes were zero
- Router replaces `:id` segments with `:slug` and expands `resources "/blog"` into explicit named routes for clarity; route order preserves `/blog/new` and `/blog/tags/:tag` priority over the catch-all `/blog/:slug`
- Feed controller `<link>` and `<guid>` elements now use `post.slug` — RSS readers will show all existing items as new (known tradeoff)
- The slug `"new"` is rejected at the changeset level to prevent a routing conflict with the create form

## Test plan

- [x] `mix test` — 198 tests, 0 failures
- [x] New test: `update_blog_post/2 preserves slug when title changes`
- [x] New assertion in create test: slug is correctly derived from title
- [x] Manually verify `/blog/my-post-slug` loads the correct post
- [x] Verify `/blog/new` still opens the create form (not a 404)
- [x] Verify RSS feed at `/blog/feed.xml` contains slug-based `<link>` elements