### PR TITLE
Replace blog post textarea with Tiptap WYSIWYG editor

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -60,3 +60,91 @@ div.markdown_render a:visited {
     color: #551A8B;
 }
 /* This file is for your main application CSS */
+
+/* ── Tiptap editor ─────────────────────────────────────────────────────────── */
+
+.tiptap-toolbar {
+  display: flex;
+  gap: 3px;
+  flex-wrap: wrap;
+  margin-bottom: 4px;
+}
+
+.tiptap-toolbar button {
+  background: #fff;
+  border: 1px solid #d4d4d8;
+  border-radius: 4px;
+  padding: 4px 6px;
+  cursor: pointer;
+  color: #71717a;
+  line-height: 0;
+  display: flex;
+  align-items: center;
+}
+
+.tiptap-toolbar button:hover {
+  background: #f4f4f5;
+  color: #18181b;
+}
+
+.tiptap-toolbar button.is-active {
+  background: #f4f4f5;
+  color: #18181b;
+  border-color: #a1a1aa;
+}
+
+.tiptap-prosemirror > .ProseMirror {
+  border: 1px solid #d4d4d8;
+  border-radius: 8px;
+  padding: 10px 12px;
+  min-height: 200px;
+  outline: none;
+  font-size: 0.875rem;
+  line-height: 1.6;
+  color: #18181b;
+}
+
+.tiptap-prosemirror > .ProseMirror:focus {
+  border-color: #a1a1aa;
+  box-shadow: 0 0 0 4px rgb(39 39 42 / 0.05);
+}
+
+.tiptap-prosemirror > .ProseMirror p.is-editor-empty:first-child::before {
+  content: attr(data-placeholder);
+  color: #a1a1aa;
+  pointer-events: none;
+  float: left;
+  height: 0;
+}
+
+.tiptap-prosemirror .ProseMirror p { margin: 0 0 0.5rem; }
+.tiptap-prosemirror .ProseMirror p:last-child { margin-bottom: 0; }
+.tiptap-prosemirror .ProseMirror h2 { font-size: 1.25rem; font-weight: 700; margin: 1rem 0 0.25rem; }
+.tiptap-prosemirror .ProseMirror h3 { font-size: 1.125rem; font-weight: 600; margin: 0.75rem 0 0.25rem; }
+.tiptap-prosemirror .ProseMirror ul { list-style: disc; padding-left: 1.25rem; margin: 0 0 0.5rem; }
+.tiptap-prosemirror .ProseMirror ol { list-style: decimal; padding-left: 1.25rem; margin: 0 0 0.5rem; }
+.tiptap-prosemirror .ProseMirror li { margin-bottom: 0.2rem; }
+.tiptap-prosemirror .ProseMirror blockquote {
+  border-left: 4px solid #d4d4d8;
+  margin: 0.5rem 0;
+  padding: 0.25rem 0 0.25rem 1rem;
+  color: #71717a;
+  font-style: italic;
+}
+.tiptap-prosemirror .ProseMirror strong { font-weight: 600; }
+.tiptap-prosemirror .ProseMirror em { font-style: italic; }
+.tiptap-prosemirror .ProseMirror code {
+  font-family: ui-monospace, monospace;
+  font-size: 0.8125em;
+  background: #f4f4f5;
+  padding: 0.125rem 0.25rem;
+  border-radius: 0.25rem;
+}
+.tiptap-prosemirror .ProseMirror pre {
+  background: #f4f4f5;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0.5rem 0;
+  overflow-x: auto;
+}
+.tiptap-prosemirror .ProseMirror pre code { background: none; padding: 0; font-size: 0.875rem; }

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -21,9 +21,10 @@ import "phoenix_html"
 import {Socket} from "phoenix"
 import {LiveSocket} from "phoenix_live_view"
 import topbar from "../vendor/topbar"
+import Hooks from "./hooks"
 
 let csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
-let liveSocket = new LiveSocket("/live", Socket, {params: {_csrf_token: csrfToken}})
+let liveSocket = new LiveSocket("/live", Socket, {hooks: Hooks, params: {_csrf_token: csrfToken}})
 
 // Show progress bar on live navigation and form submits
 topbar.config({barColors: {0: "#29d"}, shadowColor: "rgba(0, 0, 0, .3)"})

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -1,0 +1,212 @@
+import { Editor } from "@tiptap/core"
+import StarterKit from "@tiptap/starter-kit"
+import { Markdown } from "tiptap-markdown"
+import Placeholder from "@tiptap/extension-placeholder"
+
+// ─── Tiptap rich-text editor ──────────────────────────────────────────────────
+
+const SHORTCUT_MAP = { b: "bold", i: "italic" }
+
+function svgIcon(paths, sw = "1.6") {
+  return (
+    `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" ` +
+    `stroke="currentColor" stroke-width="${sw}" stroke-linecap="round" ` +
+    `stroke-linejoin="round">${paths}</svg>`
+  )
+}
+
+const TOOLBAR_BTNS = [
+  {
+    action: "bold",
+    title: "Bold (Ctrl+B)",
+    svg: svgIcon(
+      `<path d="M4 3v10"/>` +
+      `<path d="M4 3h4a2.5 2.5 0 010 5H4"/>` +
+      `<path d="M4 8h4.5a2.5 2.5 0 010 5H4"/>`,
+    ),
+  },
+  {
+    action: "italic",
+    title: "Italic (Ctrl+I)",
+    svg: svgIcon(
+      `<path d="M10 3.5H6"/>` +
+      `<path d="M10 12.5H6"/>` +
+      `<path d="M9 3.5l-2 9"/>`,
+    ),
+  },
+  {
+    action: "h2",
+    title: "Heading 2",
+    svg: svgIcon(
+      `<path d="M3 3v10"/>` +
+      `<path d="M8 3v10"/>` +
+      `<path d="M3 8h5"/>` +
+      `<path d="M11 6c0-1 .9-1.8 2-1.8s2 .8 2 1.8c0 .8-.5 1.3-1.2 1.9L11 12.5h4" stroke-width="1.4"/>`,
+      "1.7",
+    ),
+  },
+  {
+    action: "h3",
+    title: "Heading 3",
+    svg: svgIcon(
+      `<path d="M3 3v10"/>` +
+      `<path d="M8 3v10"/>` +
+      `<path d="M3 8h5"/>` +
+      `<path d="M11 5.5c.4-.8 1.2-1.3 2-1.3 1.1 0 2 .7 2 1.7 0 .9-.7 1.6-1.7 1.7 1.2 0 2.1.8 2.1 1.9 0 1.2-1.1 2.1-2.4 2.1-1 0-1.9-.5-2.3-1.3" stroke-width="1.4"/>`,
+      "1.7",
+    ),
+  },
+  {
+    action: "list",
+    title: "Bullet List",
+    svg: svgIcon(
+      `<circle cx="3.2" cy="4" r="1" fill="currentColor" stroke="none"/>` +
+      `<circle cx="3.2" cy="8" r="1" fill="currentColor" stroke="none"/>` +
+      `<circle cx="3.2" cy="12" r="1" fill="currentColor" stroke="none"/>` +
+      `<path d="M6.5 4h7.5"/>` +
+      `<path d="M6.5 8h7.5"/>` +
+      `<path d="M6.5 12h7.5"/>`,
+    ),
+  },
+  {
+    action: "olist",
+    title: "Numbered List",
+    svg: svgIcon(
+      `<path d="M2 5V3l-.7.5" stroke-width="1.3"/>` +
+      `<path d="M1.5 8.5c0-.6.5-1 1-1s1 .4 1 1c0 .8-2 1.4-2 2.5h2" stroke-width="1.3"/>` +
+      `<path d="M6.5 4h7.5"/>` +
+      `<path d="M6.5 8h7.5"/>` +
+      `<path d="M6.5 12h7.5"/>`,
+    ),
+  },
+  {
+    action: "quote",
+    title: "Blockquote",
+    svg: svgIcon(
+      `<path d="M3 10c0-3 1.5-4.5 3-5"/>` +
+      `<path d="M3 10c0 1.5 1 2.5 2.2 2.5S7.5 11.5 7.5 10c0-1.4-1.1-2.4-2.3-2.4-.7 0-1.2.2-1.2.2" fill="currentColor" stroke="none"/>` +
+      `<path d="M9 10c0-3 1.5-4.5 3-5"/>` +
+      `<path d="M9 10c0 1.5 1 2.5 2.2 2.5s2.3-1 2.3-2.5c0-1.4-1.1-2.4-2.3-2.4-.7 0-1.2.2-1.2.2" fill="currentColor" stroke="none"/>`,
+      "1.4",
+    ),
+  },
+]
+
+const ACTION_COMMANDS = {
+  bold:   (ed) => ed.chain().focus().toggleBold().run(),
+  italic: (ed) => ed.chain().focus().toggleItalic().run(),
+  h2:     (ed) => ed.chain().focus().toggleHeading({ level: 2 }).run(),
+  h3:     (ed) => ed.chain().focus().toggleHeading({ level: 3 }).run(),
+  list:   (ed) => ed.chain().focus().toggleBulletList().run(),
+  olist:  (ed) => ed.chain().focus().toggleOrderedList().run(),
+  quote:  (ed) => ed.chain().focus().toggleBlockquote().run(),
+}
+
+const ACTIVE_CHECKS = {
+  bold:   (ed) => ed.isActive("bold"),
+  italic: (ed) => ed.isActive("italic"),
+  h2:     (ed) => ed.isActive("heading", { level: 2 }),
+  h3:     (ed) => ed.isActive("heading", { level: 3 }),
+  list:   (ed) => ed.isActive("bulletList"),
+  olist:  (ed) => ed.isActive("orderedList"),
+  quote:  (ed) => ed.isActive("blockquote"),
+}
+
+const TiptapEditor = {
+  mounted() {
+    this._toolbar = this._buildToolbar()
+    this._proseMirrorEl = document.createElement("div")
+    this._proseMirrorEl.className = "tiptap-prosemirror"
+    this._hiddenInput = document.createElement("input")
+    this._hiddenInput.type = "hidden"
+    this._hiddenInput.name = this.el.dataset.fieldName || "content"
+    this.el.appendChild(this._toolbar)
+    this.el.appendChild(this._proseMirrorEl)
+    this.el.appendChild(this._hiddenInput)
+    this._editor = this._initEditor()
+    this._keydown = this._onKeydown.bind(this)
+    this.el.addEventListener("keydown", this._keydown)
+  },
+
+  destroyed() {
+    this.el.removeEventListener("keydown", this._keydown)
+    if (this._editor) this._editor.destroy()
+  },
+
+  _buildToolbar() {
+    const toolbar = document.createElement("div")
+    toolbar.className = "tiptap-toolbar"
+    TOOLBAR_BTNS.forEach(({ action, title, svg }) => {
+      const btn = document.createElement("button")
+      btn.type = "button"
+      btn.dataset.action = action
+      btn.title = title
+      btn.innerHTML = svg
+      toolbar.appendChild(btn)
+    })
+    toolbar.addEventListener("mousedown", (e) => {
+      const btn = e.target.closest("button[data-action]")
+      if (!btn) return
+      e.preventDefault()
+      this._handleToolbarClick(btn)
+    })
+    return toolbar
+  },
+
+  _handleToolbarClick(btn) {
+    this._runAction(btn.dataset.action)
+  },
+
+  _initEditor() {
+    const initial = this.el.dataset.initial || ""
+    const ed = new Editor({
+      element: this._proseMirrorEl,
+      extensions: [
+        StarterKit.configure({ heading: { levels: [2, 3] } }),
+        Markdown.configure({ html: false }),
+        Placeholder.configure({ placeholder: "Write something…" }),
+      ],
+      content: initial,
+      onUpdate: () => this._onUpdate(),
+      onSelectionUpdate: () => this._updateActiveStates(),
+    })
+    this._hiddenInput.value = initial
+    return ed
+  },
+
+  _onUpdate() {
+    const md = this._editor.storage.markdown.getMarkdown()
+    this._hiddenInput.value = md
+    this._hiddenInput.dispatchEvent(new Event("input", { bubbles: true }))
+  },
+
+  _runAction(action) {
+    const cmd = ACTION_COMMANDS[action]
+    if (!cmd) return
+    cmd(this._editor)
+    this._updateActiveStates()
+  },
+
+  _updateActiveStates() {
+    const btns = this._toolbar.querySelectorAll("button[data-action]")
+    btns.forEach((btn) => {
+      const check = ACTIVE_CHECKS[btn.dataset.action]
+      if (!check) return
+      btn.classList.toggle("is-active", check(this._editor))
+    })
+  },
+
+  _hasModifier(e) {
+    return e.ctrlKey || e.metaKey
+  },
+
+  _onKeydown(e) {
+    if (!this._hasModifier(e)) return
+    const action = SHORTCUT_MAP[e.key.toLowerCase()]
+    if (!action) return
+    e.preventDefault()
+    this._runAction(action)
+  },
+}
+
+export default { TiptapEditor }

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -5,8 +5,6 @@ import Placeholder from "@tiptap/extension-placeholder"
 
 // ─── Tiptap rich-text editor ──────────────────────────────────────────────────
 
-const SHORTCUT_MAP = { b: "bold", i: "italic" }
-
 function svgIcon(paths, sw = "1.6") {
   return (
     `<svg width="16" height="16" viewBox="0 0 16 16" fill="none" ` +
@@ -18,7 +16,7 @@ function svgIcon(paths, sw = "1.6") {
 const TOOLBAR_BTNS = [
   {
     action: "bold",
-    title: "Bold (Ctrl+B)",
+    title: "Bold",
     svg: svgIcon(
       `<path d="M4 3v10"/>` +
       `<path d="M4 3h4a2.5 2.5 0 010 5H4"/>` +
@@ -27,7 +25,7 @@ const TOOLBAR_BTNS = [
   },
   {
     action: "italic",
-    title: "Italic (Ctrl+I)",
+    title: "Italic",
     svg: svgIcon(
       `<path d="M10 3.5H6"/>` +
       `<path d="M10 12.5H6"/>` +
@@ -124,12 +122,9 @@ const TiptapEditor = {
     this.el.appendChild(this._proseMirrorEl)
     this.el.appendChild(this._hiddenInput)
     this._editor = this._initEditor()
-    this._keydown = this._onKeydown.bind(this)
-    this.el.addEventListener("keydown", this._keydown)
   },
 
   destroyed() {
-    this.el.removeEventListener("keydown", this._keydown)
     if (this._editor) this._editor.destroy()
   },
 
@@ -196,17 +191,6 @@ const TiptapEditor = {
     })
   },
 
-  _hasModifier(e) {
-    return e.ctrlKey || e.metaKey
-  },
-
-  _onKeydown(e) {
-    if (!this._hasModifier(e)) return
-    const action = SHORTCUT_MAP[e.key.toLowerCase()]
-    if (!action) return
-    e.preventDefault()
-    this._runAction(action)
-  },
 }
 
 export default { TiptapEditor }

--- a/assets/package-lock.json
+++ b/assets/package-lock.json
@@ -1,0 +1,428 @@
+{
+  "requires": true,
+  "lockfileVersion": 1,
+  "dependencies": {
+    "@tiptap/core": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.23.6.tgz",
+      "integrity": "sha512-MRB3pHz4Oxqmcawh0cQ5iOGdY5xtNYp/1CoK7hdTLzw5K0C6/gTC2VvanB1R4INaB6EpBkxG/GiWkVirDRnuXw=="
+    },
+    "@tiptap/extension-blockquote": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-blockquote/-/extension-blockquote-3.23.6.tgz",
+      "integrity": "sha512-2RmnqNqTltZ2k1F7IfjoDNs935Uq4rRDR7d98mqkg3OlDktcQIyBpv0t9dTay6H5bkQeZUuS8ogK2S1E8Edjug=="
+    },
+    "@tiptap/extension-bold": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bold/-/extension-bold-3.23.6.tgz",
+      "integrity": "sha512-1LMhjnytdbbhWHSoOwnLxZAOQZWPkKyXVCNmaIk0Mhi4tLPUXptG4qKS5sVYTCveE5H6IBPFrbgBFi5dMI6krA=="
+    },
+    "@tiptap/extension-bullet-list": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-bullet-list/-/extension-bullet-list-3.23.6.tgz",
+      "integrity": "sha512-RMRgfXZykr/13X8UBOwvpgysVOo9KchwqMoEbvqQSj4YFfU56iIn59C8sbxiQ1sKfeltUf0wH4fPc0I4iwKqAA=="
+    },
+    "@tiptap/extension-code": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code/-/extension-code-3.23.6.tgz",
+      "integrity": "sha512-KG8KXFYyLrtYvT7AZ1WGV61ofx8pDe5g9pH658MERxqQGii+Pyfc6xkz04l7XeBts/7+571UQp/0O7i/z560TA=="
+    },
+    "@tiptap/extension-code-block": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.23.6.tgz",
+      "integrity": "sha512-4kccgcn5yHThxrzsIhJny3EwfEZYIk+BjUCL4uIuzOyWvExtGhZ6JMHVCZeMhI8D1/bX1LNkkAKN5DXPzH4lXQ=="
+    },
+    "@tiptap/extension-document": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-document/-/extension-document-3.23.6.tgz",
+      "integrity": "sha512-XDAIgG9KcKumFM9KJWUEUhXPbFIhhl47bfy5GknareWTRKke85rcoj/oxKKO9ihLZr8JfpbXjqnS4SCm5yhYPw=="
+    },
+    "@tiptap/extension-dropcursor": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-dropcursor/-/extension-dropcursor-3.23.6.tgz",
+      "integrity": "sha512-+XWEoRKf3lXxi7Le1aOM2xU1XHwxICGpXjT3m4QaYqUgIpsq8gQEuso6kVg8DnTD7biKQs6+oIQ0o2b/gTW9WA=="
+    },
+    "@tiptap/extension-gapcursor": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-gapcursor/-/extension-gapcursor-3.23.6.tgz",
+      "integrity": "sha512-wbKmxXsszxWacEkrHucRpSQbiKjz4fmOebD6OVyL9AcrmlbxNk8vcM3iyh/8cVeRy09XY+morM165t/u7/z4IQ=="
+    },
+    "@tiptap/extension-hard-break": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-hard-break/-/extension-hard-break-3.23.6.tgz",
+      "integrity": "sha512-KeUm+tkUfIVSX9QM9XOIhaay0Fn36sLKUo5NVYjN3uJaxFvaZXZmTlxdO85OTdgF2P5sqh9LomrIgliaFRGk4w=="
+    },
+    "@tiptap/extension-heading": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-heading/-/extension-heading-3.23.6.tgz",
+      "integrity": "sha512-A/0jPhxnUh9THSZymlu0OGPZe1wdFdwHAXnRCmqvYUCwJjrG7LCC/ahzmcj1tcNzI9hgHyuYPSfev8RXYrNu/w=="
+    },
+    "@tiptap/extension-horizontal-rule": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-horizontal-rule/-/extension-horizontal-rule-3.23.6.tgz",
+      "integrity": "sha512-hEUlz4H+I64r+TH6LCuNCRgO7JTHncXGmx9+WbU69EOfY8O0ZurcgeJc8HeiAKL+r9YuC1e5YHfFxgCaaC0jlg=="
+    },
+    "@tiptap/extension-italic": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-italic/-/extension-italic-3.23.6.tgz",
+      "integrity": "sha512-wol5KdwCPAvpiYhH9PLlvO8ZnJHwZtIboVevrfOGgBcKlXRA3dedR4OAMXHnUtkkzu9KtliLg1+TYzEx4JZG9Q=="
+    },
+    "@tiptap/extension-link": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-link/-/extension-link-3.23.6.tgz",
+      "integrity": "sha512-KNZz7z7P2/qbQsx5bPAbSPjrKDg1VHsedGlLHJCr8U2VRD5VgmDLkMpkouP1CsDg15qgyUKv/nDib5KgPpLNWA==",
+      "requires": {
+        "linkifyjs": "^4.3.3"
+      }
+    },
+    "@tiptap/extension-list": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.23.6.tgz",
+      "integrity": "sha512-z6vj9+Qht2sjdQkyyHcUpsC/yCIZqTrQiyHDhs/HGKrfvoANyAZGpqdNeKf1wSyjIso+27tQuIH5NDfk8ygyNw=="
+    },
+    "@tiptap/extension-list-item": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-item/-/extension-list-item-3.23.6.tgz",
+      "integrity": "sha512-3zzyhdkUWcHVpXuvy6KiIwjh29rbH6gEDEqPQqHLrl1XGnO9pnShC7pSHctlCDjmcx3O4n9cd4QMtVBlUerbiA=="
+    },
+    "@tiptap/extension-list-keymap": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-list-keymap/-/extension-list-keymap-3.23.6.tgz",
+      "integrity": "sha512-x8bPcLViGzg/RAmQM/XtmfqIwQ/Pv9Q8mkd+OgfUiTqjeJqKwVQmiqbLFNa7zw81+H61M+HDU+qGAaQ3vRIMjw=="
+    },
+    "@tiptap/extension-ordered-list": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-ordered-list/-/extension-ordered-list-3.23.6.tgz",
+      "integrity": "sha512-1m/wWB/ZtXcmG2vNdiUkCqsOgqv5vBjCv/mVaHhF9OvV+zQS8YDjoWE7zEuT/GgELdT77Xq8lHrn4nCDudB3/A=="
+    },
+    "@tiptap/extension-paragraph": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-paragraph/-/extension-paragraph-3.23.6.tgz",
+      "integrity": "sha512-+7m58LUSncodjrIyXks4RZ3tLNYrvgT77wRR4l3HnM5OABY3GDsDTqi7c1t1yI29NVOSk/DUacqy6UwYAj1DGg=="
+    },
+    "@tiptap/extension-placeholder": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-placeholder/-/extension-placeholder-3.23.6.tgz",
+      "integrity": "sha512-8I6b2aevF74aLgymKMxbDxSLxWA2y+2dh0zZDeI8sRZ2m6WHHes+Kyuuwkq1HIPcR+ZLpbec74cmf6lcL/yvqQ=="
+    },
+    "@tiptap/extension-strike": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-strike/-/extension-strike-3.23.6.tgz",
+      "integrity": "sha512-oF7FEZ37f15aCe5kPgzGDYf/m+hr7VdQ/Ko/Hds/UM9pX7AG1fdtmRrl6wqkRqDM/incZaC/AQR2/Dpo2VCNGQ=="
+    },
+    "@tiptap/extension-text": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-text/-/extension-text-3.23.6.tgz",
+      "integrity": "sha512-ipoC2TkIAIOTiF5ByiGgvQB1DqDyfP90wrUB3mohBcgvp7lQnwHszCDGv8dNnmcUek8uXV/uoLu2VXeVQlxjPA=="
+    },
+    "@tiptap/extension-underline": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extension-underline/-/extension-underline-3.23.6.tgz",
+      "integrity": "sha512-P55wGIZGYTVH92Fq0cgI4/O9AhLCaJC3hhxg15RSERP5/YegM9eJHDK/GQ1EE/DvYA+xpYGOV6agKwAUqfA/Iw=="
+    },
+    "@tiptap/extensions": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.23.6.tgz",
+      "integrity": "sha512-X09/Db1teB+ifXzDGVVFmOeQRx7wTAayE9/280spxpsHkHZvJ5bHRvWIzUzviMIjbBz+NPDIKYPK7gMfh9iaig=="
+    },
+    "@tiptap/pm": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.23.6.tgz",
+      "integrity": "sha512-in5CaMaWlJcH2A1q6GJKFtrodE8WLS3M9tIi/f89jPmIVHJShpodC0KZDNyJkrVBQomYk0DEh86Utm6ASXzQww==",
+      "requires": {
+        "prosemirror-changeset": "^2.3.0",
+        "prosemirror-commands": "^1.6.2",
+        "prosemirror-dropcursor": "^1.8.1",
+        "prosemirror-gapcursor": "^1.3.2",
+        "prosemirror-history": "^1.4.1",
+        "prosemirror-keymap": "^1.2.2",
+        "prosemirror-model": "^1.24.1",
+        "prosemirror-schema-list": "^1.5.0",
+        "prosemirror-state": "^1.4.3",
+        "prosemirror-tables": "^1.6.4",
+        "prosemirror-transform": "^1.10.2",
+        "prosemirror-view": "^1.38.1"
+      }
+    },
+    "@tiptap/starter-kit": {
+      "version": "3.23.6",
+      "resolved": "https://registry.npmjs.org/@tiptap/starter-kit/-/starter-kit-3.23.6.tgz",
+      "integrity": "sha512-gykwtGWrnWCmtql1hid3opac/KV8zQvOAnu3bTqIqcHrn1FusbUwKmNzavSbfGvcktHM3hFjb35W48JyVLyu/A==",
+      "requires": {
+        "@tiptap/core": "^3.23.6",
+        "@tiptap/extension-blockquote": "^3.23.6",
+        "@tiptap/extension-bold": "^3.23.6",
+        "@tiptap/extension-bullet-list": "^3.23.6",
+        "@tiptap/extension-code": "^3.23.6",
+        "@tiptap/extension-code-block": "^3.23.6",
+        "@tiptap/extension-document": "^3.23.6",
+        "@tiptap/extension-dropcursor": "^3.23.6",
+        "@tiptap/extension-gapcursor": "^3.23.6",
+        "@tiptap/extension-hard-break": "^3.23.6",
+        "@tiptap/extension-heading": "^3.23.6",
+        "@tiptap/extension-horizontal-rule": "^3.23.6",
+        "@tiptap/extension-italic": "^3.23.6",
+        "@tiptap/extension-link": "^3.23.6",
+        "@tiptap/extension-list": "^3.23.6",
+        "@tiptap/extension-list-item": "^3.23.6",
+        "@tiptap/extension-list-keymap": "^3.23.6",
+        "@tiptap/extension-ordered-list": "^3.23.6",
+        "@tiptap/extension-paragraph": "^3.23.6",
+        "@tiptap/extension-strike": "^3.23.6",
+        "@tiptap/extension-text": "^3.23.6",
+        "@tiptap/extension-underline": "^3.23.6",
+        "@tiptap/extensions": "^3.23.6",
+        "@tiptap/pm": "^3.23.6"
+      }
+    },
+    "@types/linkify-it": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-3.0.5.tgz",
+      "integrity": "sha512-yg6E+u0/+Zjva+buc3EIb+29XEg4wltq7cSmd4Uc2EE/1nUVmxyzpX6gUXD0V8jIrG0r7YeOGVIbYRkxeooCtw=="
+    },
+    "@types/markdown-it": {
+      "version": "13.0.9",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-13.0.9.tgz",
+      "integrity": "sha512-1XPwR0+MgXLWfTn9gCsZ55AHOKW1WN+P9vr0PaQh5aerR9LLQXUbjfEAFhjmEmyoYFWAyuN2Mqkn40MZ4ukjBw==",
+      "requires": {
+        "@types/linkify-it": "^3",
+        "@types/mdurl": "^1"
+      }
+    },
+    "@types/mdurl": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-1.0.5.tgz",
+      "integrity": "sha512-6L6VymKTzYSrEf4Nev4Xa1LCHKrlTlYCBMTlQKFuddo1CvQcE52I0mwfOJayueUC7MJuXOeHTcIU683lzd0cUA=="
+    },
+    "argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
+    },
+    "entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="
+    },
+    "linkify-it": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+      "integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+      "requires": {
+        "uc.micro": "^2.0.0"
+      }
+    },
+    "linkifyjs": {
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/linkifyjs/-/linkifyjs-4.3.3.tgz",
+      "integrity": "sha512-P8aEP5U/D1/IlTY2OeYsErdwh9bGuLE30NcXtKEjgdHcahveQoQwM2yZNsioQHsWFz0P7KKudisbrzCgR0sDHg=="
+    },
+    "markdown-it": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.2.0.tgz",
+      "integrity": "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==",
+      "requires": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.1",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      }
+    },
+    "markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
+    },
+    "mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
+    },
+    "orderedmap": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/orderedmap/-/orderedmap-2.1.1.tgz",
+      "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g=="
+    },
+    "prosemirror-changeset": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-changeset/-/prosemirror-changeset-2.4.1.tgz",
+      "integrity": "sha512-96WBLhOaYhJ+kPhLg3uW359Tz6I/MfcrQfL4EGv4SrcqKEMC1gmoGrXHecPE8eOwTVCJ4IwgfzM8fFad25wNfw==",
+      "requires": {
+        "prosemirror-transform": "^1.0.0"
+      }
+    },
+    "prosemirror-commands": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-commands/-/prosemirror-commands-1.7.1.tgz",
+      "integrity": "sha512-rT7qZnQtx5c0/y/KlYaGvtG411S97UaL6gdp6RIZ23DLHanMYLyfGBV5DtSnZdthQql7W+lEVbpSfwtO8T+L2w==",
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.10.2"
+      }
+    },
+    "prosemirror-dropcursor": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/prosemirror-dropcursor/-/prosemirror-dropcursor-1.8.2.tgz",
+      "integrity": "sha512-CCk6Gyx9+Tt2sbYk5NK0nB1ukHi2ryaRgadV/LvyNuO3ena1payM2z6Cg0vO1ebK8cxbzo41ku2DE5Axj1Zuiw==",
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0",
+        "prosemirror-view": "^1.1.0"
+      }
+    },
+    "prosemirror-gapcursor": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-gapcursor/-/prosemirror-gapcursor-1.4.1.tgz",
+      "integrity": "sha512-pMdYaEnjNMSwl11yjEGtgTmLkR08m/Vl+Jj443167p9eB3HVQKhYCc4gmHVDsLPODfZfjr/MmirsdyZziXbQKw==",
+      "requires": {
+        "prosemirror-keymap": "^1.0.0",
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-view": "^1.0.0"
+      }
+    },
+    "prosemirror-history": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-history/-/prosemirror-history-1.5.0.tgz",
+      "integrity": "sha512-zlzTiH01eKA55UAf1MEjtssJeHnGxO0j4K4Dpx+gnmX9n+SHNlDqI2oO1Kv1iPN5B1dm5fsljCfqKF9nFL6HRg==",
+      "requires": {
+        "prosemirror-state": "^1.2.2",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.31.0",
+        "rope-sequence": "^1.3.0"
+      }
+    },
+    "prosemirror-keymap": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/prosemirror-keymap/-/prosemirror-keymap-1.2.3.tgz",
+      "integrity": "sha512-4HucRlpiLd1IPQQXNqeo81BGtkY8Ai5smHhKW9jjPKRc2wQIxksg7Hl1tTI2IfT2B/LgX6bfYvXxEpJl7aKYKw==",
+      "requires": {
+        "prosemirror-state": "^1.0.0",
+        "w3c-keyname": "^2.2.0"
+      }
+    },
+    "prosemirror-markdown": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-markdown/-/prosemirror-markdown-1.13.4.tgz",
+      "integrity": "sha512-D98dm4cQ3Hs6EmjK500TdAOew4Z03EV71ajEFiWra3Upr7diytJsjF4mPV2dW+eK5uNectiRj0xFxYI9NLXDbw==",
+      "requires": {
+        "@types/markdown-it": "^14.0.0",
+        "markdown-it": "^14.0.0",
+        "prosemirror-model": "^1.25.0"
+      },
+      "dependencies": {
+        "@types/linkify-it": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+          "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="
+        },
+        "@types/markdown-it": {
+          "version": "14.1.2",
+          "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+          "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+          "requires": {
+            "@types/linkify-it": "^5",
+            "@types/mdurl": "^2"
+          }
+        },
+        "@types/mdurl": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+          "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
+        }
+      }
+    },
+    "prosemirror-model": {
+      "version": "1.25.7",
+      "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.7.tgz",
+      "integrity": "sha512-A79aN8QEFUwI6cax8Yq4Rpcx1TJZ3Kagn+ii7qLo4/V8H3mMiHrhFyhTyHHvpSnOgMPpWiDGSwM3etwrxE50ug==",
+      "requires": {
+        "orderedmap": "^2.0.0"
+      }
+    },
+    "prosemirror-schema-list": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/prosemirror-schema-list/-/prosemirror-schema-list-1.5.1.tgz",
+      "integrity": "sha512-927lFx/uwyQaGwJxLWCZRkjXG0p48KpMj6ueoYiu4JX05GGuGcgzAy62dfiV8eFZftgyBUvLx76RsMe20fJl+Q==",
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.7.3"
+      }
+    },
+    "prosemirror-state": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
+      "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
+      "requires": {
+        "prosemirror-model": "^1.0.0",
+        "prosemirror-transform": "^1.0.0",
+        "prosemirror-view": "^1.27.0"
+      }
+    },
+    "prosemirror-tables": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/prosemirror-tables/-/prosemirror-tables-1.8.5.tgz",
+      "integrity": "sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==",
+      "requires": {
+        "prosemirror-keymap": "^1.2.3",
+        "prosemirror-model": "^1.25.4",
+        "prosemirror-state": "^1.4.4",
+        "prosemirror-transform": "^1.10.5",
+        "prosemirror-view": "^1.41.4"
+      }
+    },
+    "prosemirror-transform": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/prosemirror-transform/-/prosemirror-transform-1.12.0.tgz",
+      "integrity": "sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==",
+      "requires": {
+        "prosemirror-model": "^1.21.0"
+      }
+    },
+    "prosemirror-view": {
+      "version": "1.41.8",
+      "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.8.tgz",
+      "integrity": "sha512-TnKDdohEatgyZNGCDWIdccOHXhYloJwbwU+phw/a23KBvJIR9lWQWW7WHHK3vBdOLDNuF7TaX98GObUZOWkOnA==",
+      "requires": {
+        "prosemirror-model": "^1.20.0",
+        "prosemirror-state": "^1.0.0",
+        "prosemirror-transform": "^1.1.0"
+      }
+    },
+    "punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="
+    },
+    "rope-sequence": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/rope-sequence/-/rope-sequence-1.3.4.tgz",
+      "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ=="
+    },
+    "tiptap-markdown": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/tiptap-markdown/-/tiptap-markdown-0.9.0.tgz",
+      "integrity": "sha512-dKLQ9iiuGNgrlGVjrNauF/UBzWu4LYOx5pkD0jNkmQt/GOwfCJsBuzZTsf1jZ204ANHOm572mZ9PYvGh1S7tpQ==",
+      "requires": {
+        "@types/markdown-it": "^13.0.7",
+        "markdown-it": "^14.1.0",
+        "markdown-it-task-lists": "^2.1.1",
+        "prosemirror-markdown": "^1.11.1"
+      }
+    },
+    "uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
+    "w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="
+    }
+  }
+}

--- a/assets/package.json
+++ b/assets/package.json
@@ -1,0 +1,9 @@
+{
+  "dependencies": {
+    "@tiptap/core": "^3.22.5",
+    "@tiptap/extension-placeholder": "^3.22.5",
+    "@tiptap/pm": "^3.22.5",
+    "@tiptap/starter-kit": "^3.22.5",
+    "tiptap-markdown": "^0.9.0"
+  }
+}

--- a/lib/tqm_web/live/blog_post_live/form.ex
+++ b/lib/tqm_web/live/blog_post_live/form.ex
@@ -10,7 +10,6 @@ defmodule TqmWeb.BlogPostLive.Form do
   def mount(_params, _session, socket) do
     {:ok,
      assign(socket,
-       mode: :write,
        tlp: :blog,
        scheduling: false,
        publish_status: :draft,
@@ -49,10 +48,6 @@ defmodule TqmWeb.BlogPostLive.Form do
   end
 
   @impl true
-  def handle_event("set_mode", %{"mode" => mode}, socket) do
-    {:noreply, assign(socket, mode: String.to_existing_atom(mode))}
-  end
-
   def handle_event("validate", %{"blog_post" => params}, socket) do
     tag_names = Enum.join(socket.assigns.selected_tag_names, ", ")
 

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -2,160 +2,145 @@
   {if @live_action == :new, do: "New post", else: "Edit post"}
 </.header>
 
-<div class="flex gap-4 mt-4 mb-2 border-b border-zinc-200">
-  <button
-    phx-click="set_mode"
-    phx-value-mode="write"
-    class={"pb-2 text-sm font-semibold " <> if(@mode == :write, do: "border-b-2 border-zinc-900 text-zinc-900", else: "text-zinc-500 hover:text-zinc-700")}
-  >
-    Write
-  </button>
-  <button
-    phx-click="set_mode"
-    phx-value-mode="preview"
-    class={"pb-2 text-sm font-semibold " <> if(@mode == :preview, do: "border-b-2 border-zinc-900 text-zinc-900", else: "text-zinc-500 hover:text-zinc-700")}
-  >
-    Preview
-  </button>
-</div>
-
-<div :if={@mode == :write}>
-  <.simple_form
-    :let={f}
-    for={@changeset}
-    id="blog_post_form"
-    phx-change="validate"
-    phx-submit="save"
-  >
-    <.error :if={@changeset.action}>
-      Oops, something went wrong! Please check the errors below.
-    </.error>
-    <.input field={{f, :title}} type="text" label="Title" />
-    <div :if={@live_action == :new}>
-      <.input
-        field={{f, :slug}}
-        type="text"
-        label="Slug"
-        phx-change="lock_slug"
-        phx-debounce="200"
-      />
-      <p :if={not @slug_locked} class="mt-1 text-xs text-zinc-400">
-        Auto-populated from title
-      </p>
-    </div>
-    <.input field={{f, :content}} type="textarea" label="Content" />
-    <div>
-      <label class="block text-sm font-semibold leading-6 text-zinc-900">Tags</label>
-      <div :if={@selected_tag_names != []} class="mt-2 flex flex-wrap gap-1.5">
-        <%= for name <- @selected_tag_names do %>
-          <span class="inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700">
-            {name}
-            <button
-              type="button"
-              phx-click="remove_tag"
-              phx-value-name={name}
-              aria-label={"Remove #{name}"}
-              class="ml-0.5 rounded-full p-0.5 text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600"
-            >
-              <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true">
-                <path d="M6.414 5l3.293-3.293a1 1 0 00-1.414-1.414L5 3.586 1.707.293A1 1 0 00.293 1.707L3.586 5 .293 8.293a1 1 0 101.414 1.414L5 6.414l3.293 3.293a1 1 0 001.414-1.414L6.414 5z" />
-              </svg>
-            </button>
-          </span>
-        <% end %>
-      </div>
-      <div class="relative mt-2">
-        <input
-          type="text"
-          name="tag_search"
-          value={@tag_search}
-          phx-keyup="search_tags"
-          phx-debounce="200"
-          placeholder="Search tags..."
-          autocomplete="off"
-          class="block w-full rounded-lg border border-zinc-300 py-[7px] px-[11px] text-zinc-900 focus:border-zinc-400 focus:outline-none focus:ring-4 focus:ring-zinc-800/5 sm:text-sm sm:leading-6"
-        />
-        <ul
-          :if={@tag_suggestions != [] or @tag_create_option != nil}
-          class="absolute z-10 mt-1 w-full rounded-md border border-zinc-200 bg-white py-1 shadow-lg text-sm text-zinc-700"
-        >
-          <li :for={tag <- @tag_suggestions}>
-            <button
-              type="button"
-              phx-click="select_tag"
-              phx-value-name={tag.name}
-              class="w-full px-4 py-2 text-left hover:bg-zinc-50"
-            >
-              {tag.name}
-            </button>
-          </li>
-          <li :if={@tag_create_option != nil}>
-            <button
-              type="button"
-              phx-click="select_tag"
-              phx-value-name={@tag_create_option}
-              class="w-full px-4 py-2 text-left hover:bg-zinc-50"
-            >
-              {@tag_create_option}
-              <span class="text-zinc-400">(create new)</span>
-            </button>
-          </li>
-        </ul>
-      </div>
-    </div>
-    <:actions>
-      <div class="flex flex-wrap items-center gap-3">
-        <.button>Save</.button>
-        <.button
-          :if={@live_action == :edit and @publish_status in [:draft, :scheduled]}
-          type="button"
-          phx-click="publish_now"
-        >
-          Publish now
-        </.button>
-        <button
-          :if={@live_action == :edit and @publish_status in [:draft, :scheduled]}
-          type="button"
-          phx-click="show_schedule_form"
-          class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
-        >
-          {if @publish_status == :scheduled, do: "Reschedule", else: "Schedule publishing"}
-        </button>
-      </div>
-    </:actions>
-  </.simple_form>
-
-  <div :if={@live_action == :edit} class="mt-4">
-    <p :if={@publish_status == :scheduled} class="text-sm text-zinc-600 mb-3">
-      Scheduled for {Calendar.strftime(@blog_post.published_at, "%B %-d, %Y at %H:%M UTC")}
+<.simple_form
+  :let={f}
+  for={@changeset}
+  id="blog_post_form"
+  phx-change="validate"
+  phx-submit="save"
+>
+  <.error :if={@changeset.action}>
+    Oops, something went wrong! Please check the errors below.
+  </.error>
+  <.input field={{f, :title}} type="text" label="Title" />
+  <div :if={@live_action == :new}>
+    <.input
+      field={{f, :slug}}
+      type="text"
+      label="Slug"
+      phx-change="lock_slug"
+      phx-debounce="200"
+    />
+    <p :if={not @slug_locked} class="mt-1 text-xs text-zinc-400">
+      Auto-populated from title
     </p>
-    <p :if={@publish_status == :published} class="text-sm text-zinc-600 mb-3">
-      Published on {Calendar.strftime(@blog_post.published_at, "%B %-d, %Y")}
-    </p>
-    <form :if={@scheduling} phx-submit="schedule" class="flex flex-wrap items-center gap-3">
+  </div>
+  <div>
+    <label class="block text-sm font-semibold leading-6 text-zinc-900">Content</label>
+    <div
+      id="tiptap-content"
+      phx-hook="TiptapEditor"
+      phx-update="ignore"
+      data-field-name="blog_post[content]"
+      data-initial={Ecto.Changeset.get_field(@changeset, :content) || ""}
+      class="mt-2"
+    >
+    </div>
+  </div>
+  <div>
+    <label class="block text-sm font-semibold leading-6 text-zinc-900">Tags</label>
+    <div :if={@selected_tag_names != []} class="mt-2 flex flex-wrap gap-1.5">
+      <%= for name <- @selected_tag_names do %>
+        <span class="inline-flex items-center gap-1 rounded-full bg-zinc-100 px-2.5 py-1 text-xs font-medium text-zinc-700">
+          {name}
+          <button
+            type="button"
+            phx-click="remove_tag"
+            phx-value-name={name}
+            aria-label={"Remove #{name}"}
+            class="ml-0.5 rounded-full p-0.5 text-zinc-400 hover:bg-zinc-200 hover:text-zinc-600"
+          >
+            <svg class="h-2.5 w-2.5" viewBox="0 0 10 10" fill="currentColor" aria-hidden="true">
+              <path d="M6.414 5l3.293-3.293a1 1 0 00-1.414-1.414L5 3.586 1.707.293A1 1 0 00.293 1.707L3.586 5 .293 8.293a1 1 0 101.414 1.414L5 6.414l3.293 3.293a1 1 0 001.414-1.414L6.414 5z" />
+            </svg>
+          </button>
+        </span>
+      <% end %>
+    </div>
+    <div class="relative mt-2">
       <input
-        type="datetime-local"
-        name="scheduled_at"
-        required
-        class="block rounded-lg text-zinc-900 focus:outline-none focus:ring-4 sm:text-sm sm:leading-6 border-zinc-300 focus:border-zinc-400 focus:ring-zinc-800/5"
+        type="text"
+        name="tag_search"
+        value={@tag_search}
+        phx-keyup="search_tags"
+        phx-debounce="200"
+        placeholder="Search tags..."
+        autocomplete="off"
+        class="block w-full rounded-lg border border-zinc-300 py-[7px] px-[11px] text-zinc-900 focus:border-zinc-400 focus:outline-none focus:ring-4 focus:ring-zinc-800/5 sm:text-sm sm:leading-6"
       />
-      <.button type="submit">Confirm</.button>
-      <button
+      <ul
+        :if={@tag_suggestions != [] or @tag_create_option != nil}
+        class="absolute z-10 mt-1 w-full rounded-md border border-zinc-200 bg-white py-1 shadow-lg text-sm text-zinc-700"
+      >
+        <li :for={tag <- @tag_suggestions}>
+          <button
+            type="button"
+            phx-click="select_tag"
+            phx-value-name={tag.name}
+            class="w-full px-4 py-2 text-left hover:bg-zinc-50"
+          >
+            {tag.name}
+          </button>
+        </li>
+        <li :if={@tag_create_option != nil}>
+          <button
+            type="button"
+            phx-click="select_tag"
+            phx-value-name={@tag_create_option}
+            class="w-full px-4 py-2 text-left hover:bg-zinc-50"
+          >
+            {@tag_create_option}
+            <span class="text-zinc-400">(create new)</span>
+          </button>
+        </li>
+      </ul>
+    </div>
+  </div>
+  <:actions>
+    <div class="flex flex-wrap items-center gap-3">
+      <.button>Save</.button>
+      <.button
+        :if={@live_action == :edit and @publish_status in [:draft, :scheduled]}
         type="button"
-        phx-click="hide_schedule_form"
+        phx-click="publish_now"
+      >
+        Publish now
+      </.button>
+      <button
+        :if={@live_action == :edit and @publish_status in [:draft, :scheduled]}
+        type="button"
+        phx-click="show_schedule_form"
         class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
       >
-        Cancel
+        {if @publish_status == :scheduled, do: "Reschedule", else: "Schedule publishing"}
       </button>
-    </form>
-  </div>
-</div>
+    </div>
+  </:actions>
+</.simple_form>
 
-<div :if={@mode == :preview} class="max-w-2xl mx-auto mt-6">
-  <h1 class="text-2xl font-bold mb-1">
-    {Ecto.Changeset.get_field(@changeset, :title) || "Untitled"}
-  </h1>
-  <.markdown_content markdown={Ecto.Changeset.get_field(@changeset, :content) || ""} />
+<div :if={@live_action == :edit} class="mt-4">
+  <p :if={@publish_status == :scheduled} class="text-sm text-zinc-600 mb-3">
+    Scheduled for {Calendar.strftime(@blog_post.published_at, "%B %-d, %Y at %H:%M UTC")}
+  </p>
+  <p :if={@publish_status == :published} class="text-sm text-zinc-600 mb-3">
+    Published on {Calendar.strftime(@blog_post.published_at, "%B %-d, %Y")}
+  </p>
+  <form :if={@scheduling} phx-submit="schedule" class="flex flex-wrap items-center gap-3">
+    <input
+      type="datetime-local"
+      name="scheduled_at"
+      required
+      class="block rounded-lg text-zinc-900 focus:outline-none focus:ring-4 sm:text-sm sm:leading-6 border-zinc-300 focus:border-zinc-400 focus:ring-zinc-800/5"
+    />
+    <.button type="submit">Confirm</.button>
+    <button
+      type="button"
+      phx-click="hide_schedule_form"
+      class="text-sm font-semibold leading-6 text-zinc-900 hover:text-zinc-700"
+    >
+      Cancel
+    </button>
+  </form>
 </div>
 
 <.back navigate={~p"/blog"}>Back to blog</.back>

--- a/test/tqm_web/live/blog_post_live_test.exs
+++ b/test/tqm_web/live/blog_post_live_test.exs
@@ -37,8 +37,8 @@ defmodule TqmWeb.BlogPostLive.FormTest do
 
       assert {:error, {:live_redirect, %{to: path}}} =
                lv
-               |> form("#blog_post_form", blog_post: %{title: "My title", content: "My content"})
-               |> render_submit()
+               |> form("#blog_post_form", blog_post: %{title: "My title"})
+               |> render_submit(%{blog_post: %{content: "My content"}})
 
       assert path == ~p"/blog/my-title"
       assert html_response(get(owner_conn, path), 200) =~ "My title"
@@ -89,7 +89,7 @@ defmodule TqmWeb.BlogPostLive.FormTest do
 
       result =
         lv
-        |> form("#blog_post_form", blog_post: %{title: "", content: ""})
+        |> form("#blog_post_form", blog_post: %{title: ""})
         |> render_submit()
 
       assert result =~ "Oops, something went wrong!"
@@ -151,40 +151,10 @@ defmodule TqmWeb.BlogPostLive.FormTest do
 
       result =
         lv
-        |> form("#blog_post_form", blog_post: %{title: "", content: ""})
+        |> form("#blog_post_form", blog_post: %{title: ""})
         |> render_submit()
 
       assert result =~ "Oops, something went wrong!"
-    end
-  end
-
-  describe "write/preview mode" do
-    test "toggles between write and preview", %{conn: conn} do
-      {:ok, lv, _html} =
-        conn
-        |> log_in_person(owner_person_fixture())
-        |> live(~p"/blog/new")
-
-      html = lv |> element("button", "Preview") |> render_click()
-      assert html =~ "Untitled"
-
-      html = lv |> element("button", "Write") |> render_click()
-      assert html =~ "Title"
-    end
-
-    test "preview reflects live changeset content", %{conn: conn} do
-      {:ok, lv, _html} =
-        conn
-        |> log_in_person(owner_person_fixture())
-        |> live(~p"/blog/new")
-
-      lv
-      |> form("#blog_post_form", blog_post: %{title: "Preview title", content: "Preview content"})
-      |> render_change()
-
-      html = lv |> element("button", "Preview") |> render_click()
-      assert html =~ "Preview title"
-      assert html =~ "Preview content"
     end
   end
 


### PR DESCRIPTION
## Summary

- Adds Tiptap (`@tiptap/starter-kit`, `tiptap-markdown`, and friends) via npm in `assets/`
- Introduces a `TiptapEditor` LiveView hook that mounts a WYSIWYG editor with a formatting toolbar (bold, italic, h2, h3, lists, blockquote) and Ctrl/Cmd+B/I keyboard shortcuts
- Replaces the plain-text content textarea on the blog post form; the write/preview tab toggle is removed since formatting is visible inline
- Content is still stored as plain markdown — `tiptap-markdown`'s `getMarkdown()` serialises on every keystroke into a hidden `blog_post[content]` input, so the database schema and all downstream rendering are unchanged

## Test plan

- [x] Create a new blog post — confirm formatting toolbar works, slug auto-populates, post saves and renders correctly
- [x] Edit an existing post — confirm existing markdown content loads into the editor correctly
- [x] Verify bold/italic keyboard shortcuts (Ctrl+B, Ctrl+I) work
- [x] Verify headings, lists, and blockquote toolbar buttons work
- [x] Confirm tags, publish now, and schedule publishing flows still work
- [x] Run `mix test` — 198 tests, 0 failures