### PR TITLE
Enforce 80% test coverage in CI

### DIFF
--- a/.github/workflows/elixir.yaml
+++ b/.github/workflows/elixir.yaml
@@ -111,6 +111,6 @@ jobs:
     - name: Check Formatting
       run: mix format --check-formatted
 
-    # Step: Execute the tests.
+    # Step: Execute the tests with coverage enforcement.
     - name: Run tests
-      run: mix test
+      run: mix test --cover

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,11 @@ defmodule Tqm.MixProject do
       start_permanent: Mix.env() == :prod,
       listeners: if(Mix.env() == :dev, do: [Phoenix.CodeReloader], else: []),
       aliases: aliases(),
-      deps: deps()
+      deps: deps(),
+      test_coverage: [
+        summary: [threshold: 80],
+        ignore_modules: [Tqm.Release, Tqm.Seeds]
+      ]
     ]
   end
 

--- a/test/tqm_web/live/about_live_test.exs
+++ b/test/tqm_web/live/about_live_test.exs
@@ -1,0 +1,66 @@
+defmodule TqmWeb.AboutLive.IndexTest do
+  use TqmWeb.ConnCase, async: true
+
+  import Phoenix.LiveViewTest
+  import Tqm.JobsFixtures
+
+  # The role_fixture doesn't associate roles with jobs (job_id isn't cast by
+  # Role.changeset), so we need to set it explicitly.
+  defp create_job_with_role(job_attrs \\ %{}, role_attrs \\ %{}) do
+    job = job_fixture(job_attrs)
+
+    role_attrs =
+      Enum.into(role_attrs, %{
+        start_date: ~D[2023-01-01],
+        end_date: ~D[2023-12-31],
+        title: "Engineer",
+        details: "Did engineering things"
+      })
+
+    {:ok, _role} =
+      %Tqm.Jobs.Role{}
+      |> Tqm.Jobs.Role.changeset(role_attrs)
+      |> Ecto.Changeset.put_change(:job_id, job.id)
+      |> Tqm.Repo.insert()
+
+    job
+  end
+
+  describe "about page" do
+    test "renders the page", %{conn: conn} do
+      {:ok, _lv, html} = live(conn, ~p"/about")
+      assert html =~ "About Me"
+      assert html =~ "Professional History"
+    end
+
+    test "lists jobs with company names", %{conn: conn} do
+      job = create_job_with_role(%{company_name: "Acme Corp"})
+      {:ok, _lv, html} = live(conn, ~p"/about")
+      assert html =~ job.company_name
+    end
+
+    test "sorts jobs by most recent start date first", %{conn: conn} do
+      old_job = create_job_with_role(%{company_name: "Old Corp"}, %{start_date: ~D[2020-01-01]})
+      new_job = create_job_with_role(%{company_name: "New Corp"}, %{start_date: ~D[2024-01-01]})
+      {:ok, _lv, html} = live(conn, ~p"/about")
+      {new_pos, _} = :binary.match(html, new_job.company_name)
+      {old_pos, _} = :binary.match(html, old_job.company_name)
+      assert new_pos < old_pos
+    end
+  end
+
+  describe "JobWithTogglableDetails component" do
+    test "initially hides job details", %{conn: conn} do
+      create_job_with_role()
+      {:ok, _lv, html} = live(conn, ~p"/about")
+      assert html =~ ~s(style="display: none;")
+    end
+
+    test "clicking job summary toggles details visibility", %{conn: conn} do
+      job = create_job_with_role()
+      {:ok, lv, _html} = live(conn, ~p"/about")
+      lv |> element("#summary-#{job.id}") |> render_click()
+      refute render(lv) =~ ~s(style="display: none;")
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds `test_coverage: [summary: [threshold: 80], ignore_modules: [Tqm.Release, Tqm.Seeds]]` to `mix.exs` — uses Elixir's built-in coverage tool, no new deps required
- Updates CI to run `mix test --cover` so the threshold is checked on every PR (previously CI ran `mix test` with no coverage check at all)
- Adds tests for `TqmWeb.AboutLive.Index` and `TqmWeb.LiveComponents.JobWithTogglableDetails`, which were both at 0% and pulling the total below the threshold

**Coverage after this PR: 83.14%** (threshold: 80%, ~3% headroom)

`Tqm.Release` and `Tqm.Seeds` are excluded — they're ops/seed scripts that aren't meaningfully unit-testable.

## Test plan

- [ ] `mix test --cover` passes locally with ≥80% total
- [ ] CI passes on this PR
- [ ] Verify the new AboutLive tests cover page render, job listing, sort order, and the toggle component