### PR TITLE
Fix Enter key in tag search submitting form instead of selecting tag

### DIFF
--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -194,14 +194,58 @@ const TiptapEditor = {
 }
 
 // ─── Tag search keyboard handling ─────────────────────────────────────────────
+//
+// Hook lives on the wrapper div (not the input) so it owns the dropdown too.
+// MutationObserver resets the highlight to index 0 whenever the dropdown's
+// children change (new suggestions or closed). Style mutations don't trigger
+// childList observers, so _applyHighlight() never causes a loop.
 
 const TagSearch = {
   mounted() {
-    this.el.addEventListener("keydown", (e) => {
-      if (e.key !== "Enter") return
-      e.preventDefault()
-      const firstOption = this.el.parentElement.querySelector("ul button")
-      if (firstOption) firstOption.click()
+    this.highlightedIndex = -1
+    this._input = this.el.querySelector("input[name='tag_search']")
+
+    this._observer = new MutationObserver(() => {
+      const options = this._getOptions()
+      this.highlightedIndex = options.length > 0 ? 0 : -1
+      this._applyHighlight(options)
+    })
+    this._observer.observe(this.el, { childList: true, subtree: true })
+
+    this._input.addEventListener("keydown", (e) => {
+      const options = this._getOptions()
+      if (e.key === "ArrowDown") {
+        e.preventDefault()
+        if (options.length === 0) return
+        this.highlightedIndex =
+          this.highlightedIndex < options.length - 1 ? this.highlightedIndex + 1 : 0
+        this._applyHighlight(options)
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault()
+        if (options.length === 0) return
+        this.highlightedIndex =
+          this.highlightedIndex <= 0 ? options.length - 1 : this.highlightedIndex - 1
+        this._applyHighlight(options)
+      } else if (e.key === "Enter") {
+        e.preventDefault()
+        const idx = this.highlightedIndex >= 0 ? this.highlightedIndex : 0
+        const target = options[idx]
+        if (target) target.click()
+      }
+    })
+  },
+
+  destroyed() {
+    if (this._observer) this._observer.disconnect()
+  },
+
+  _getOptions() {
+    return Array.from(this.el.querySelectorAll("ul button"))
+  },
+
+  _applyHighlight(options) {
+    options.forEach((btn, i) => {
+      btn.style.background = i === this.highlightedIndex ? "var(--bg-alt)" : "none"
     })
   },
 }

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -193,4 +193,17 @@ const TiptapEditor = {
 
 }
 
-export default { TiptapEditor }
+// ─── Tag search keyboard handling ─────────────────────────────────────────────
+
+const TagSearch = {
+  mounted() {
+    this.el.addEventListener("keydown", (e) => {
+      if (e.key !== "Enter") return
+      e.preventDefault()
+      const firstOption = this.el.parentElement.querySelector("ul button")
+      if (firstOption) firstOption.click()
+    })
+  },
+}
+
+export default { TiptapEditor, TagSearch }

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -154,7 +154,11 @@
             </button>
           </span>
         <% end %>
-        <div id="tag_search_container" phx-hook="TagSearch" style="flex: 1; min-width: 200px; position: relative;">
+        <div
+          id="tag_search_container"
+          phx-hook="TagSearch"
+          style="flex: 1; min-width: 200px; position: relative;"
+        >
           <input
             type="text"
             name="tag_search"

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -154,13 +154,11 @@
             </button>
           </span>
         <% end %>
-        <div style="flex: 1; min-width: 200px; position: relative;">
+        <div id="tag_search_container" phx-hook="TagSearch" style="flex: 1; min-width: 200px; position: relative;">
           <input
             type="text"
-            id="tag_search"
             name="tag_search"
             value={@tag_search}
-            phx-hook="TagSearch"
             phx-keyup="search_tags"
             phx-debounce="200"
             placeholder="Search or create a tag…"

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -157,8 +157,10 @@
         <div style="flex: 1; min-width: 200px; position: relative;">
           <input
             type="text"
+            id="tag_search"
             name="tag_search"
             value={@tag_search}
+            phx-hook="TagSearch"
             phx-keyup="search_tags"
             phx-debounce="200"
             placeholder="Search or create a tag…"


### PR DESCRIPTION
## Summary

- Pressing Enter while the tag search dropdown was open triggered form submission, navigating away without adding the intended tag
- Added a `TagSearch` LiveView hook that intercepts `keydown` on the tag input: if Enter is pressed and a dropdown option is visible, it clicks that first button instead of letting the event bubble to the form
- Enter is suppressed entirely when focused on the tag input — save is only reachable via the Save button or ⌘S, which is the expected interaction

## Test plan

- [ ] Type in the tag search to open the dropdown, press Enter — first suggestion is selected, no navigation occurs
- [ ] Type a new tag name (no existing match), press Enter — "create new" option is selected
- [ ] Clear the tag search (empty dropdown), press Enter — nothing happens, page stays
- [ ] Save via the Save button still works normally