### PR TITLE
Add foreword field to blog posts

### DIFF
--- a/lib/tqm/blog/blog_post.ex
+++ b/lib/tqm/blog/blog_post.ex
@@ -5,6 +5,7 @@ defmodule Tqm.Blog.BlogPost do
 
   schema "blog_posts" do
     field :content, :string
+    field :foreword, :string
     field :published_at, :utc_datetime
     field :title, :string
     field :slug, :string
@@ -18,7 +19,7 @@ defmodule Tqm.Blog.BlogPost do
   @doc false
   def changeset(blog_post, attrs) do
     blog_post
-    |> cast(attrs, [:title, :content, :published_at, :tag_names, :slug])
+    |> cast(attrs, [:title, :content, :foreword, :published_at, :tag_names, :slug])
     |> validate_required([:title, :content])
     |> maybe_put_slug()
     |> validate_exclusion(:slug, ~w(new), message: "is reserved — choose a different title")

--- a/lib/tqm_web/controllers/blog_post_html/show.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/show.html.heex
@@ -28,6 +28,17 @@
 
   <h1 class="qm-h1" style="font-size: 60px; margin-bottom: 32px;">{@blog_post.title}</h1>
 
+  <%= if @blog_post.foreword do %>
+    <aside style="margin-bottom: 48px; padding: 20px 24px; border-radius: 10px; background: var(--bg-alt); border: 1px solid var(--line-2);">
+      <p style="margin: 0 0 10px; font-family: var(--mono); font-size: 10px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted);">
+        Foreword
+      </p>
+      <div class="qm-post-body" style="font-style: italic; color: var(--ink-2);">
+        {@blog_post.foreword |> Earmark.as_html!() |> Phoenix.HTML.raw()}
+      </div>
+    </aside>
+  <% end %>
+
   <div class="qm-post-body">
     {@blog_post.content |> Earmark.as_html!() |> Phoenix.HTML.raw()}
   </div>

--- a/lib/tqm_web/live/blog_post_live/form.html.heex
+++ b/lib/tqm_web/live/blog_post_live/form.html.heex
@@ -118,6 +118,24 @@
       <% end %>
     </div>
     <div style="margin-bottom: 32px;">
+      <label
+        for="blog_post_form_foreword"
+        style="display: block; font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted); margin-bottom: 10px;"
+      >
+        Foreword
+        <span style="font-weight: 400; text-transform: none; letter-spacing: 0; opacity: 0.6;">
+          — optional, rendered before the post body
+        </span>
+      </label>
+      <textarea
+        id="blog_post_form_foreword"
+        name="blog_post[foreword]"
+        rows="4"
+        placeholder="Add context about when or why this was written…"
+        style="width: 100%; padding: 14px 16px; border-radius: 10px; border: 1px solid var(--line-2); background: transparent; font-family: var(--serif); font-size: 16px; color: var(--ink); outline: none; box-sizing: border-box; resize: vertical; line-height: 1.6;"
+      >{Ecto.Changeset.get_field(@changeset, :foreword) || ""}</textarea>
+    </div>
+    <div style="margin-bottom: 32px;">
       <label style="display: block; font-family: var(--mono); font-size: 11px; text-transform: uppercase; letter-spacing: 0.14em; color: var(--muted); margin-bottom: 10px;">
         Content
       </label>

--- a/priv/repo/migrations/20260525120000_add_foreword_to_blog_posts.exs
+++ b/priv/repo/migrations/20260525120000_add_foreword_to_blog_posts.exs
@@ -1,0 +1,9 @@
+defmodule Tqm.Repo.Migrations.AddForewordToBlogPosts do
+  use Ecto.Migration
+
+  def change do
+    alter table(:blog_posts) do
+      add :foreword, :text
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Adds a nullable `foreword` text column to `blog_posts` for editorial context separate from the article body (e.g. for reprinted undergrad articles)
- On the show page, renders the foreword between the title and body as a labeled aside — inset background, muted border, italic text, small "FOREWORD" label — clearly distinct from the post content
- On the edit/new form, adds a plain textarea (not Tiptap) between the slug and content fields; supports markdown rendered via Earmark

## Test plan

- [x] Create a new post with a foreword — confirm it appears as the styled aside block on the show page
- [x] Create a post without a foreword — confirm the aside block is absent
- [x] Confirm markdown in the foreword renders correctly (e.g. `_italic_`, links)
- [x] Edit an existing post to add/remove a foreword — confirm save round-trips correctly