### PR TITLE
Add footnote/citation support to blog post rendering

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -253,10 +253,9 @@ div.markdown_render a:visited {
 .qm-post-body a.footnote:hover { color: var(--ink); }
 .qm-post-body .footnotes { margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--line); font-size: 15px; color: var(--muted); }
 .qm-post-body .footnotes ol { padding-left: 1.25rem; margin: 16px 0 0; }
-.qm-post-body .footnotes li { margin-bottom: 8px; line-height: 1.5; }
-.qm-post-body .footnotes p { margin: 0; font-size: inherit; color: inherit; }
-.qm-post-body .footnotes p:first-child { font-family: inherit; font-size: inherit; color: inherit; }
-.qm-post-body a.reversefootnote { font-family: var(--mono); font-size: 0.85em; color: var(--muted); background-image: none; padding: 0 0 0 4px; }
+.qm-post-body .footnotes li { display: flex; flex-wrap: wrap; align-items: baseline; margin-bottom: 8px; line-height: 1.5; }
+.qm-post-body .footnotes p { order: 0; margin: 0; font-size: inherit; color: inherit; }
+.qm-post-body a.reversefootnote { order: 1; font-family: var(--mono); font-size: 0.85em; color: var(--muted); background-image: none; padding: 0 0 0 0.3em; }
 .qm-post-body a.reversefootnote:hover { color: var(--ink); }
 
 /* ── Admin pill ─────────────────────────────────────────────────────────── */

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -248,6 +248,16 @@ div.markdown_render a:visited {
 .qm-post-body code { font-family: var(--mono); font-size: 0.85em; background: var(--bg-alt); padding: 2px 5px; border-radius: 4px; }
 .qm-post-body pre { background: var(--bg-alt); border-radius: 8px; padding: 1rem; margin: 0 0 20px; overflow-x: auto; }
 .qm-post-body pre code { background: none; padding: 0; font-size: 0.875rem; }
+.qm-post-body sup { font-size: 0.7em; line-height: 0; vertical-align: super; }
+.qm-post-body a.footnote { font-family: var(--mono); font-size: 0.7em; color: var(--muted); background-image: none; padding-bottom: 0; }
+.qm-post-body a.footnote:hover { color: var(--ink); }
+.qm-post-body .footnotes { margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--line); font-size: 15px; color: var(--muted); }
+.qm-post-body .footnotes ol { padding-left: 1.25rem; margin: 16px 0 0; }
+.qm-post-body .footnotes li { margin-bottom: 8px; line-height: 1.5; }
+.qm-post-body .footnotes p { margin: 0; font-size: inherit; color: inherit; }
+.qm-post-body .footnotes p:first-child { font-family: inherit; font-size: inherit; color: inherit; }
+.qm-post-body a.reversefootnote { font-family: var(--mono); font-size: 0.85em; color: var(--muted); background-image: none; padding: 0 0 0 4px; }
+.qm-post-body a.reversefootnote:hover { color: var(--ink); }
 
 /* ── Admin pill ─────────────────────────────────────────────────────────── */
 .qm-admin-pill { margin-left: 10px; padding: 2px 8px; border-radius: 999px; background: var(--accent-soft); color: var(--accent); font-size: 10px; letter-spacing: 0.12em; font-family: var(--mono); text-transform: uppercase; vertical-align: middle; }

--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -252,8 +252,9 @@ div.markdown_render a:visited {
 .qm-post-body a.footnote { font-family: var(--mono); font-size: 0.7em; color: var(--muted); background-image: none; padding-bottom: 0; }
 .qm-post-body a.footnote:hover { color: var(--ink); }
 .qm-post-body .footnotes { margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--line); font-size: 15px; color: var(--muted); }
-.qm-post-body .footnotes ol { padding-left: 1.25rem; margin: 16px 0 0; }
-.qm-post-body .footnotes li { display: flex; flex-wrap: wrap; align-items: baseline; margin-bottom: 8px; line-height: 1.5; }
+.qm-post-body .footnotes ol { list-style: none; counter-reset: footnote; padding-left: 0; margin: 16px 0 0; }
+.qm-post-body .footnotes li { display: flex; flex-wrap: wrap; align-items: baseline; margin-bottom: 8px; line-height: 1.5; counter-increment: footnote; }
+.qm-post-body .footnotes li::before { content: counter(footnote) ". "; flex-shrink: 0; }
 .qm-post-body .footnotes p { order: 0; margin: 0; font-size: inherit; color: inherit; }
 .qm-post-body a.reversefootnote { order: 1; font-family: var(--mono); font-size: 0.85em; color: var(--muted); background-image: none; padding: 0 0 0 0.3em; }
 .qm-post-body a.reversefootnote:hover { color: var(--ink); }

--- a/assets/js/hooks.js
+++ b/assets/js/hooks.js
@@ -170,7 +170,11 @@ const TiptapEditor = {
   },
 
   _onUpdate(editor) {
+    // prosemirror-markdown escapes all square brackets, which breaks footnote
+    // syntax ([^1] → \[^1\]). Restore it: [^ is exclusively footnote syntax
+    // in Earmark so this replacement is unambiguous.
     const md = editor.storage.markdown.getMarkdown()
+      .replace(/\\\[(\^[^\]]+)\\\]/g, "[$1]")
     this._hiddenInput.value = md
     this._hiddenInput.dispatchEvent(new Event("input", { bubbles: true }))
   },

--- a/lib/tqm_web/controllers/blog_post_html/show.html.heex
+++ b/lib/tqm_web/controllers/blog_post_html/show.html.heex
@@ -34,13 +34,13 @@
         Foreword
       </p>
       <div class="qm-post-body" style="font-style: italic; color: var(--ink-2);">
-        {@blog_post.foreword |> Earmark.as_html!() |> Phoenix.HTML.raw()}
+        {@blog_post.foreword |> Earmark.as_html!(footnotes: true) |> Phoenix.HTML.raw()}
       </div>
     </aside>
   <% end %>
 
   <div class="qm-post-body">
-    {@blog_post.content |> Earmark.as_html!() |> Phoenix.HTML.raw()}
+    {@blog_post.content |> Earmark.as_html!(footnotes: true) |> Phoenix.HTML.raw()}
   </div>
 
   <div style="margin-top: 56px; padding-top: 24px; border-top: 1px solid var(--line); display: flex; justify-content: space-between; align-items: center;">


### PR DESCRIPTION
## Summary

- Earmark has Pandoc-style footnote support built in but it was off — passes `footnotes: true` to both `as_html!` calls (content and foreword) on the show page
- Adds CSS for all the elements Earmark generates: inline superscript references, the footnotes section at the bottom, and the ↩ back-links

## Syntax

In the post editor, write footnotes using standard Pandoc markdown:

```
This claim needs a citation.[^1] And this one too.[^note]

[^1]: First source, Author Name, 2003.
[^note]: Second source, with a longer description.
```

The Tiptap editor has no special footnote UI — the `[^n]` syntax appears as plain text while editing, but is preserved in the stored markdown and rendered correctly on the published page.

## Test plan

- [ ] Write a post with `[^1]` inline references and `[^1]: ...` definitions — confirm superscript links and footnote section render on the show page
- [ ] Confirm the ↩ back-links navigate back to the reference point
- [ ] Confirm posts without footnotes are unaffected